### PR TITLE
fix: add vite aliases for components and lib

### DIFF
--- a/src/components/DialogEditor.tsx
+++ b/src/components/DialogEditor.tsx
@@ -32,7 +32,7 @@ function Graph() {
       ...proj,
       dialogs: [
         { ...d0, nodes: [...d0.nodes, { id, text: "Новая реплика", choices: [] }] },
-        *proj.dialogs.slice(1)
+        ...proj.dialogs.slice(1)
       ]
     } as any
     setProj(validateDialogProject(next))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [react()],
   server: { port: 5173 },
+  resolve: {
+    alias: {
+      '@components': fileURLToPath(new URL('./src/components', import.meta.url)),
+      '@lib': fileURLToPath(new URL('./src/lib', import.meta.url)),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vite to resolve `@components` and `@lib` aliases
- fix DialogEditor spread error when adding nodes

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898fed6a17c8333bc84c9078425890a