### PR TITLE
ci: run CI on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## Summary
- run workflow on Windows and macOS in addition to Linux

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68990d13afd8833396734b236de94827