### PR TITLE
Fix TypeScript test expectations and FileReader stub

### DIFF
--- a/src/lib/dialogSchema.test.ts
+++ b/src/lib/dialogSchema.test.ts
@@ -18,7 +18,6 @@ describe('dialogSchema', () => {
   })
 
   it('rejects invalid data', () => {
-    // @ts-expect-error testing invalid structure
     expect(() => validateDialogProject({ version: 1 })).toThrow()
   })
 })

--- a/src/lib/sceneSchema.test.ts
+++ b/src/lib/sceneSchema.test.ts
@@ -23,7 +23,6 @@ describe('sceneSchema', () => {
   })
 
   it('rejects invalid data', () => {
-    // @ts-expect-error testing invalid
     expect(() => validateSceneProject({ project: {} })).toThrow()
   })
 })

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -49,10 +49,10 @@ describe('file helpers', () => {
 
     class FR {
       result: string | ArrayBuffer | null = null
-      onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null = null
+      onload: ((ev: ProgressEvent<FileReader>) => any) | null = null
       readAsText(f: File) {
         this.result = content
-        this.onload && this.onload(new ProgressEvent('load'))
+        this.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>)
       }
     }
     // @ts-ignore override


### PR DESCRIPTION
## Summary
- remove unused `@ts-expect-error` directives from schema tests
- fix FileReader test stub to avoid invalid `this` context

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68990d84041c8333b4da6d7f0b57e954