### PR TITLE
Fix hotspot tests and mock FileReader for type checking

### DIFF
--- a/src/components/HotspotShape.test.ts
+++ b/src/components/HotspotShape.test.ts
@@ -22,6 +22,7 @@ function mockCtx() {
     arc: vi.fn(),
     fillRect: vi.fn(),
     strokeRect: vi.fn(),
+    translate: vi.fn(),
     // properties set
     strokeStyle: '',
     fillStyle: '',
@@ -32,9 +33,9 @@ function mockCtx() {
 describe('drawHotspot', () => {
   it('draws different shapes without error', () => {
     const ctx = mockCtx()
-    drawHotspot(ctx, proj, { id: 'r', shape: 'rect', rect: { x: 0, y: 0, w: 0.2, h: 0.2 } }, 100, 100)
-    drawHotspot(ctx, proj, { id: 'p', shape: 'polygon', points: [[0,0],[0.2,0],[0,0.2]] }, 100, 100)
-    drawHotspot(ctx, proj, { id: 'c', shape: 'circle', circle: { cx:0.5, cy:0.5, r:0.1 } }, 100, 100)
+    drawHotspot(ctx, proj, { id: 'r', hidden: false, shape: 'rect', rect: { x: 0, y: 0, w: 0.2, h: 0.2 } }, 100, 100)
+    drawHotspot(ctx, proj, { id: 'p', hidden: false, shape: 'polygon', points: [[0,0],[0.2,0],[0,0.2]] }, 100, 100)
+    drawHotspot(ctx, proj, { id: 'c', hidden: false, shape: 'circle', circle: { cx:0.5, cy:0.5, r:0.1 } }, 100, 100)
     expect(ctx.fillRect).toHaveBeenCalled()
     expect(ctx.arc).toHaveBeenCalled()
   })
@@ -42,34 +43,34 @@ describe('drawHotspot', () => {
 
 describe('hit testing and transformations', () => {
   it('detects hits for shapes', () => {
-    const rect: Hotspot = { id:'r', shape:'rect', rect:{x:0,y:0,w:0.2,h:0.2} }
+    const rect: Hotspot = { id:'r', hidden:false, shape:'rect', rect:{x:0,y:0,w:0.2,h:0.2} }
     expect(hitTestHotspot(proj, rect, 100,100,10,10)?.kind).toBe('move')
 
-    const poly: Hotspot = { id:'p', shape:'polygon', points:[[0,0],[0.2,0],[0,0.2]] }
+    const poly: Hotspot = { id:'p', hidden:false, shape:'polygon', points:[[0,0],[0.2,0],[0,0.2]] }
     expect(hitTestHotspot(proj, poly, 100,100,0,0)).toEqual({ kind:'vertex', index:0 })
 
-    const circle: Hotspot = { id:'c', shape:'circle', circle:{cx:0.5, cy:0.5, r:0.1} }
+    const circle: Hotspot = { id:'c', hidden:false, shape:'circle', circle:{cx:0.5, cy:0.5, r:0.1} }
     expect(hitTestHotspot(proj, circle, 100,100,60,50)?.kind).toBe('radius')
     expect(hitTestHotspot(proj, circle, 100,100,50,50)?.kind).toBe('move')
   })
 
   it('translates hotspots', () => {
-    const rect: Hotspot = { id:'r', shape:'rect', rect:{x:0,y:0,w:0.1,h:0.1} }
+    const rect: Hotspot = { id:'r', hidden:false, shape:'rect', rect:{x:0,y:0,w:0.1,h:0.1} }
     translateHotspot(rect, proj, 10, 20, 100, 100)
     expect(rect.rect?.x).toBeCloseTo(0.1)
     expect(rect.rect?.y).toBeCloseTo(0.2)
 
-    const poly: Hotspot = { id:'p', shape:'polygon', points:[[0,0],[0.1,0.1]] }
+    const poly: Hotspot = { id:'p', hidden:false, shape:'polygon', points:[[0,0],[0.1,0.1]] }
     translateHotspot(poly, proj, 10, 0, 100, 100)
     expect(poly.points?.[0][0]).toBeCloseTo(0.1)
 
-    const circle: Hotspot = { id:'c', shape:'circle', circle:{cx:0.1, cy:0.1, r:0.1} }
+    const circle: Hotspot = { id:'c', hidden:false, shape:'circle', circle:{cx:0.1, cy:0.1, r:0.1} }
     translateHotspot(circle, proj, 10, 10, 100, 100)
     expect(circle.circle?.cx).toBeCloseTo(0.2)
   })
 
   it('modifies polygon vertices and circle radius', () => {
-    const poly: Hotspot = { id:'p', shape:'polygon', points:[[0,0],[0.2,0]] }
+    const poly: Hotspot = { id:'p', hidden:false, shape:'polygon', points:[[0,0],[0.2,0]] }
     moveVertexTo(poly, proj, 1, 30, 40, 100, 100)
     expect(poly.points?.[1][0]).toBeCloseTo(0.3)
     expect(poly.points?.[1][1]).toBeCloseTo(0.4)
@@ -78,7 +79,7 @@ describe('hit testing and transformations', () => {
     expect(poly.points).toHaveLength(3)
     expect(poly.points?.[1][0]).toBeCloseTo(0.1)
 
-    const circle: Hotspot = { id:'c', shape:'circle', circle:{cx:0.1, cy:0.1, r:0.1} }
+    const circle: Hotspot = { id:'c', hidden:false, shape:'circle', circle:{cx:0.1, cy:0.1, r:0.1} }
     setCircleRadius(circle, proj, 30, 10, 100, 100)
     expect(circle.circle?.r).toBeCloseTo(0.2)
   })

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -47,14 +47,18 @@ describe('file helpers', () => {
     // @ts-ignore override
     document.createElement = vi.fn((tag: string) => tag === 'input' ? input : originalCreateElement.call(document, tag))
 
-    class FR {
-      result: string | ArrayBuffer | null = null
-      onload: ((ev: ProgressEvent<FileReader>) => any) | null = null
-      readAsText(f: File) {
-        this.result = content
-        this.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>)
+      class FR {
+        result: string | ArrayBuffer | null = null
+        onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null = null
+        readAsText(_f: File) {
+          this.result = content
+          // call onload with correct `this` context to satisfy TS
+          this.onload?.call(
+            this as unknown as FileReader,
+            new ProgressEvent('load') as ProgressEvent<FileReader>
+          )
+        }
       }
-    }
     // @ts-ignore override
     global.FileReader = FR
 


### PR DESCRIPTION
## Summary
- include `hidden` flag in Hotspot test fixtures and stub canvas `translate`
- fix FileReader mock to call `onload` with proper context

## Testing
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6899107abc348333b5ca1cc9f5203bbb