### PR TITLE
Fix horizontal grid rendering in ScenesEditor

### DIFF
--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -45,7 +45,7 @@ export default function ScenesEditor() {
     ctx.globalAlpha = 1
     ctx.strokeStyle = "#e9e9e9"
     for (let x=0; x<W; x+=40) { ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,H); ctx.stroke() }
-    for (let y=0; y<H; y+=40) { ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(0+y,0+y); ctx.moveTo(0,y); ctx.lineTo(W,y); ctx.stroke() }
+    for (let y=0; y<H; y+=40) { ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(W,y); ctx.stroke() }
     // background hint
     ctx.fillStyle = "#fafafa"
     ctx.fillRect(0,0,W,H)


### PR DESCRIPTION
## Summary
- simplify horizontal grid loop in ScenesEditor to avoid stray diagonal line and draw only horizontal grid lines

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991214e7bc83339cab0c41405d6459