### PR TITLE
Clean up temporary DOM elements in file utils

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -39,9 +39,11 @@ describe('file helpers', () => {
     const content = 'hello world'
     const file = new File([content], 'test.txt', { type: 'text/plain' })
 
+    const remove = vi.fn()
     const input: any = {
       type: '', accept: '', files: [file], onchange: null,
-      click: () => input.onchange && input.onchange()
+      click: () => input.onchange && input.onchange(),
+      remove
     }
     const originalCreateElement = document.createElement
     // @ts-ignore override
@@ -64,13 +66,15 @@ describe('file helpers', () => {
 
     const text = await loadFileAsText('.txt')
     expect(text).toBe(content)
+    expect(remove).toHaveBeenCalled()
 
     document.createElement = originalCreateElement
   })
 
   it('triggers download when saving text', () => {
     const click = vi.fn()
-    const anchor: any = { href: '', download: '', click }
+    const remove = vi.fn()
+    const anchor: any = { href: '', download: '', click, remove }
     const originalCreate = document.createElement
     // @ts-ignore
     document.createElement = vi.fn((tag: string) => tag === 'a' ? anchor : originalCreate(tag))
@@ -86,6 +90,7 @@ describe('file helpers', () => {
 
     expect(createURL).toHaveBeenCalled()
     expect(click).toHaveBeenCalled()
+    expect(remove).toHaveBeenCalled()
     expect(revokeURL).toHaveBeenCalled()
 
     document.createElement = originalCreate

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,9 +5,15 @@ export function loadFileAsText(accept = "*"): Promise<string | null> {
     input.accept = accept
     input.onchange = () => {
       const file = input.files?.[0]
-      if (!file) return resolve(null)
+      if (!file) {
+        input.remove()
+        return resolve(null)
+      }
       const reader = new FileReader()
-      reader.onload = () => resolve(String(reader.result))
+      reader.onload = () => {
+        resolve(String(reader.result))
+        input.remove()
+      }
       reader.readAsText(file)
     }
     input.click()
@@ -21,6 +27,7 @@ export function saveTextFile(content: string, filename: string) {
   a.href = url
   a.download = filename
   a.click()
+  a.remove()
   URL.revokeObjectURL(url)
 }
 


### PR DESCRIPTION
## Summary
- Remove temporary file input after reading to prevent DOM leaks
- Clean up download anchor element after triggering save
- Update tests to cover element cleanup

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6899121a33248333a92bf55129d31b3d