### PR TITLE
Use structuredClone for hotspot cloning and test special values

### DIFF
--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -161,7 +161,7 @@ export default function ScenesEditor() {
       if (hit) {
         setSelectedHs(i)
         if (hit.kind === "add") {
-          const hsCopy: Hotspot = JSON.parse(JSON.stringify(hs))
+          const hsCopy: Hotspot = structuredClone(hs)
           insertVertex(hsCopy, proj, hit.index, x, y, W, H)
           const hotspots = scene.hotspots!.map((h,j)=> j===i?hsCopy:h)
           const next = { ...proj, scenes: proj.scenes.map(s => s.id===scene.id? {...s, hotspots}: s) }
@@ -192,7 +192,7 @@ export default function ScenesEditor() {
     const W = canvas.width, H = canvas.height
     const scene = proj.scenes[sceneIndex]
     const hs = scene.hotspots![drag.hsIndex]
-    const hsCopy: Hotspot = JSON.parse(JSON.stringify(hs))
+    const hsCopy: Hotspot = structuredClone(hs)
     if (drag.mode === "move") {
       translateHotspot(hsCopy, proj, x - drag.prevX, y - drag.prevY, W, H)
     } else if (drag.mode === "vertex" && drag.vertexIndex !== undefined) {

--- a/src/components/hotspotClone.test.ts
+++ b/src/components/hotspotClone.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import type { Hotspot } from '@lib/sceneSchema'
+
+describe('hotspot cloning', () => {
+  it('preserves undefined and Date properties', () => {
+    const original: Hotspot & { created: Date } = {
+      id: 'hs1',
+      shape: 'rect',
+      rect: { x: 0.1, y: 0.2, w: 0.3, h: 0.4 },
+      tooltip: undefined,
+      created: new Date('2024-06-01T00:00:00Z'),
+    }
+    const copy = structuredClone(original)
+    expect(copy).not.toBe(original)
+    expect('tooltip' in copy).toBe(true)
+    expect(copy.tooltip).toBeUndefined()
+    expect(copy.created).toBeInstanceOf(Date)
+    expect(copy.created.getTime()).toBe(original.created.getTime())
+  })
+})


### PR DESCRIPTION
## Summary
- replace JSON deep copy in `ScenesEditor` with `structuredClone`
- add test ensuring hotspot cloning preserves `undefined` properties and `Date`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6899122d04808333893e5bc1a400646f