### PR TITLE
refactor: add typed node and edge data

### DIFF
--- a/src/components/DialogEditor.tsx
+++ b/src/components/DialogEditor.tsx
@@ -4,37 +4,52 @@ import 'reactflow/dist/style.css'
 import { DialogProject, emptyDialogProject, validateDialogProject } from "@lib/dialogSchema"
 import { loadFileAsText, saveTextFile } from "@lib/utils"
 
+interface DialogNodeData {
+  label: string
+}
+
+interface DialogEdgeData {}
+
+type DialogNode = Node<DialogNodeData>
+type DialogEdge = Edge<DialogEdgeData>
+
 function Graph() {
   const [proj, setProj] = useState<DialogProject>(emptyDialogProject())
-  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([] as any)
-  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([] as any)
+  const [nodes, setNodes, onNodesChange] = useNodesState<DialogNodeData>([])
+  const [edges, setEdges, onEdgesChange] = useEdgesState<DialogEdgeData>([])
   const [status, setStatus] = useState("")
 
   useEffect(() => {
     // project -> graph
-    const ns: Node[] = proj.dialogs.flatMap(d => d.nodes.map((n, idx) => ({
-      id: n.id,
-      data: { label: (n.text?.slice(0,40) || n.id) },
-      position: { x: (idx%6)*180, y: Math.floor(idx/6)*120 }
-    }))) as any
-    const es: Edge[] = proj.dialogs.flatMap(d => d.nodes.flatMap(n => (n.choices||[]).map(c => ({
-      id: `${n.id}->${c.next}`,
-      source: n.id,
-      target: (c.next||n.id)
-    })))) as any
+    const ns: DialogNode[] = proj.dialogs.flatMap(d =>
+      d.nodes.map((n, idx): DialogNode => ({
+        id: n.id,
+        data: { label: n.text?.slice(0, 40) || n.id },
+        position: { x: (idx % 6) * 180, y: Math.floor(idx / 6) * 120 }
+      }))
+    )
+    const es: DialogEdge[] = proj.dialogs.flatMap(d =>
+      d.nodes.flatMap(n =>
+        (n.choices || []).map((c): DialogEdge => ({
+          id: `${n.id}->${c.next}`,
+          source: n.id,
+          target: c.next || n.id
+        }))
+      )
+    )
     setNodes(ns); setEdges(es)
   }, [proj])
 
   function addNode() {
     const id = "n_" + Math.random().toString(36).slice(2,8)
-    const d0 = proj.dialogs[0] || { id: "dlg_1", nodes: [] }
-    const next = {
+    const d0: DialogProject["dialogs"][number] = proj.dialogs[0] || { id: "dlg_1", nodes: [] }
+    const next: DialogProject = {
       ...proj,
       dialogs: [
         { ...d0, nodes: [...d0.nodes, { id, text: "Новая реплика", choices: [] }] },
         ...proj.dialogs.slice(1)
       ]
-    } as any
+    }
     setProj(validateDialogProject(next))
     setStatus("Добавлен узел-реплика")
   }
@@ -44,11 +59,11 @@ function Graph() {
     const d0 = proj.dialogs[0]
     if (!d0) return
     const nodes = d0.nodes.map(n => n.id===c.source
-      ? { ...n, choices: [...(n.choices||[]), { text: "→", next: c.target }] }
+      ? { ...n, choices: [...(n.choices || []), { text: "→", next: c.target! }] }
       : n
     )
-    const next = { ...proj, dialogs: [{ ...d0, nodes }] }
-    setProj(validateDialogProject(next as any))
+    const next: DialogProject = { ...proj, dialogs: [{ ...d0, nodes }] }
+    setProj(validateDialogProject(next))
     setStatus(`Связь: ${c.source} → ${c.target}`)
     setEdges(eds => addEdge({ source: c.source!, target: c.target!, id: `${c.source}->${c.target}` }, eds))
   }


### PR DESCRIPTION
## Summary
- define DialogNodeData and DialogEdgeData interfaces
- use typed generics for React Flow nodes and edges
- remove `as any` casts when building graph structures

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68991223b6dc8333926938051690b7e4