### PR TITLE
test: restore globals

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -35,6 +35,18 @@ describe('coordinate helpers', () => {
 })
 
 describe('file helpers', () => {
+  const originalCreateElement = document.createElement
+  const originalFileReader = global.FileReader
+  const originalCreateObjectURL = global.URL.createObjectURL
+  const originalRevokeObjectURL = global.URL.revokeObjectURL
+
+  afterEach(() => {
+    document.createElement = originalCreateElement
+    global.FileReader = originalFileReader
+    global.URL.createObjectURL = originalCreateObjectURL
+    global.URL.revokeObjectURL = originalRevokeObjectURL
+  })
+
   it('reads text from selected file', async () => {
     const content = 'hello world'
     const file = new File([content], 'test.txt', { type: 'text/plain' })
@@ -43,37 +55,33 @@ describe('file helpers', () => {
       type: '', accept: '', files: [file], onchange: null,
       click: () => input.onchange && input.onchange()
     }
-    const originalCreateElement = document.createElement
     // @ts-ignore override
     document.createElement = vi.fn((tag: string) => tag === 'input' ? input : originalCreateElement.call(document, tag))
 
-      class FR {
-        result: string | ArrayBuffer | null = null
-        onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null = null
-        readAsText(_f: File) {
-          this.result = content
-          // call onload with correct `this` context to satisfy TS
-          this.onload?.call(
-            this as unknown as FileReader,
-            new ProgressEvent('load') as ProgressEvent<FileReader>
-          )
-        }
+    class FR {
+      result: string | ArrayBuffer | null = null
+      onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null = null
+      readAsText(_f: File) {
+        this.result = content
+        // call onload with correct `this` context to satisfy TS
+        this.onload?.call(
+          this as unknown as FileReader,
+          new ProgressEvent('load') as ProgressEvent<FileReader>
+        )
       }
+    }
     // @ts-ignore override
     global.FileReader = FR
 
     const text = await loadFileAsText('.txt')
     expect(text).toBe(content)
-
-    document.createElement = originalCreateElement
   })
 
   it('triggers download when saving text', () => {
     const click = vi.fn()
     const anchor: any = { href: '', download: '', click }
-    const originalCreate = document.createElement
     // @ts-ignore
-    document.createElement = vi.fn((tag: string) => tag === 'a' ? anchor : originalCreate(tag))
+    document.createElement = vi.fn((tag: string) => tag === 'a' ? anchor : originalCreateElement.call(document, tag))
 
     const createURL = vi.fn(() => 'blob:url')
     const revokeURL = vi.fn()
@@ -87,7 +95,5 @@ describe('file helpers', () => {
     expect(createURL).toHaveBeenCalled()
     expect(click).toHaveBeenCalled()
     expect(revokeURL).toHaveBeenCalled()
-
-    document.createElement = originalCreate
   })
 })


### PR DESCRIPTION
## Summary
- ensure file helper tests restore globals

## Testing
- `npx vitest run`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6899121de9e88333b7a40b8b5387c543