### PR TITLE
Add missing hidden property in hotspot clone test

### DIFF
--- a/src/components/hotspotClone.test.ts
+++ b/src/components/hotspotClone.test.ts
@@ -6,6 +6,7 @@ describe('hotspot cloning', () => {
     const original: Hotspot & { created: Date } = {
       id: 'hs1',
       shape: 'rect',
+      hidden: false,
       rect: { x: 0.1, y: 0.2, w: 0.3, h: 0.4 },
       tooltip: undefined,
       created: new Date('2024-06-01T00:00:00Z'),


### PR DESCRIPTION
## Summary
- fix hotspot clone test to include required `hidden` property so typecheck passes

## Testing
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689914833ac08333bf076b40ac9af9ba