### PR TITLE
Add screen size presets and coordinate mode toggle

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -5,7 +5,9 @@ import {
   projectToCanvasPoint,
   canvasToProjectPoint,
   loadFileAsText,
-  saveTextFile
+  saveTextFile,
+  round3,
+  convertProjectCoordsMode
 } from './utils'
 import type { SceneProject } from './sceneSchema'
 
@@ -31,6 +33,25 @@ describe('coordinate helpers', () => {
     const back = canvasToProjectPoint(proj, 100, 50, 200, 200)
     expect(back.x).toBeCloseTo(0.5)
     expect(back.y).toBeCloseTo(0.25)
+  })
+
+  it('rounds numbers to 3 decimals', () => {
+    expect(round3(0.123456)).toBe(0.123)
+    expect(round3(0.1235)).toBe(0.124)
+  })
+
+  it('converts project coordinate modes', () => {
+    const src: SceneProject = {
+      version: '1.0',
+      project: { reference_resolution: { width: 100, height: 100 }, coords_mode: 'relative' },
+      scenes: [{ id: 's', layers: [], hotspots: [{ id: 'h', shape: 'rect', rect: { x: 0.1, y: 0.2, w: 0.3, h: 0.4 } }] }]
+    }
+    const abs = convertProjectCoordsMode(src, 'absolute')
+    expect(abs.project.coords_mode).toBe('absolute')
+    expect(abs.scenes[0].hotspots[0].rect!.w).toBe(30)
+    const back = convertProjectCoordsMode(abs, 'relative')
+    expect(back.project.coords_mode).toBe('relative')
+    expect(back.scenes[0].hotspots[0].rect!.w).toBeCloseTo(0.3)
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,14 +32,19 @@ export function saveTextFile(content: string, filename: string) {
 }
 
 // coordinate helpers
-import type { SceneProject } from "@lib/sceneSchema"
+import type { SceneProject, Hotspot } from "@lib/sceneSchema"
+
+export function round3(value: number): number {
+  return Math.round(value * 1000) / 1000
+}
 
 export function projectToCanvasScalar(proj: SceneProject, value: number, canvasSize: number, refSize: number): number {
   return proj.project.coords_mode === "relative" ? value * canvasSize : value * (canvasSize / refSize)
 }
 
 export function canvasToProjectScalar(proj: SceneProject, value: number, canvasSize: number, refSize: number): number {
-  return proj.project.coords_mode === "relative" ? value / canvasSize : value / (canvasSize / refSize)
+  const v = proj.project.coords_mode === "relative" ? value / canvasSize : value / (canvasSize / refSize)
+  return round3(v)
 }
 
 export function projectToCanvasPoint(proj: SceneProject, x: number, y: number, canvasW: number, canvasH: number) {
@@ -57,5 +62,48 @@ export function canvasToProjectPoint(proj: SceneProject, x: number, y: number, c
   return {
     x: canvasToProjectScalar(proj, x, canvasW, refW),
     y: canvasToProjectScalar(proj, y, canvasH, refH)
+  }
+}
+
+export function convertProjectCoordsMode(proj: SceneProject, mode: 'relative' | 'absolute'): SceneProject {
+  if (proj.project.coords_mode === mode) return proj
+  const refW = proj.project.reference_resolution.width
+  const refH = proj.project.reference_resolution.height
+  const scenes = proj.scenes.map(scene => ({
+    ...scene,
+    hotspots: scene.hotspots?.map(hs => convertHotspot(hs)) ?? []
+  }))
+  return { ...proj, project: { ...proj.project, coords_mode: mode }, scenes }
+
+  function convertHotspot(hs: Hotspot): Hotspot {
+    if (hs.shape === 'rect' && hs.rect) {
+      const { x, y, w, h } = hs.rect
+      return {
+        ...hs,
+        rect: {
+          x: mode === 'relative' ? round3(x / refW) : round3(x * refW),
+          y: mode === 'relative' ? round3(y / refH) : round3(y * refH),
+          w: mode === 'relative' ? round3(w / refW) : round3(w * refW),
+          h: mode === 'relative' ? round3(h / refH) : round3(h * refH),
+        }
+      }
+    } else if (hs.shape === 'circle' && hs.circle) {
+      const { cx, cy, r } = hs.circle
+      return {
+        ...hs,
+        circle: {
+          cx: mode === 'relative' ? round3(cx / refW) : round3(cx * refW),
+          cy: mode === 'relative' ? round3(cy / refH) : round3(cy * refH),
+          r: mode === 'relative' ? round3(r / refW) : round3(r * refW),
+        }
+      }
+    } else if (hs.shape === 'polygon' && hs.points) {
+      const pts = hs.points.map(([px, py]) => [
+        mode === 'relative' ? round3(px / refW) : round3(px * refW),
+        mode === 'relative' ? round3(py / refH) : round3(py * refH)
+      ]) as typeof hs.points
+      return { ...hs, points: pts }
+    }
+    return hs
   }
 }


### PR DESCRIPTION
## Summary
- Add screen resolution presets with manual entry mode and coordinate mode selector
- Limit hotspot numeric fields to 3 decimal places
- Introduce rounding and coordinate mode conversion helpers with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991bcc62d88333a648c1c5b33ff9a8