### PR TITLE
test: handle empty file selection

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -112,6 +112,23 @@ describe('file helpers', () => {
     document.createElement = originalCreateElement
   })
 
+  it('returns null and removes element when no file selected', async () => {
+    const remove = vi.fn()
+    const input: any = {
+      type: '', accept: '', files: [], onchange: null,
+      click: () => input.onchange && input.onchange(),
+      remove
+    }
+    // @ts-ignore override
+    document.createElement = vi.fn((tag: string) => tag === 'input' ? input : originalCreateElement.call(document, tag))
+
+    const text = await loadFileAsText('.txt')
+    expect(text).toBeNull()
+    expect(remove).toHaveBeenCalled()
+
+    document.createElement = originalCreateElement
+  })
+
   it('triggers download when saving text', () => {
     const click = vi.fn()
     const remove = vi.fn()


### PR DESCRIPTION
## Summary
- add unit test ensuring `loadFileAsText` returns null when no file selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68991d7d16b88333b40c837cfad95e07