### PR TITLE
test: verify hotspot structuredClone in ScenesEditor

### DIFF
--- a/src/components/ScenesEditor.test.tsx
+++ b/src/components/ScenesEditor.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import type { Hotspot } from '@lib/sceneSchema'
 
-describe('hotspot cloning', () => {
+// ScenesEditor uses structuredClone when manipulating hotspots.
+// This test ensures that cloning a hotspot preserves undefined fields and Date instances.
+describe('ScenesEditor hotspot cloning', () => {
   it('preserves undefined and Date properties', () => {
     const original: Hotspot & { created: Date } = {
       id: 'hs1',


### PR DESCRIPTION
## Summary
- replace `hotspotClone.test.ts` with `ScenesEditor.test.tsx`
- ensure cloning preserves `undefined` fields and `Date` instances

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991d80dba0833389639a115f8ef039