### PR TITLE
Add layer editing panels and canvas layer rendering

### DIFF
--- a/src/components/CanvasView.tsx
+++ b/src/components/CanvasView.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from "react"
+import type { Layer } from "@lib/sceneSchema"
+
+type Props = {
+  layers: Layer[]
+  width: number
+  height: number
+}
+
+export default function CanvasView({ layers, width, height }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const cacheRef = useRef<Map<string, HTMLImageElement>>(new Map())
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext("2d")!
+
+    function draw() {
+      ctx.clearRect(0, 0, width, height)
+      const sorted = [...layers].sort((a, b) => a.zorder - b.zorder)
+      for (const layer of sorted) {
+        if (layer.type === "color") {
+          ctx.globalAlpha = layer.alpha ?? 1
+          ctx.fillStyle = layer.color
+          ctx.fillRect(0, 0, width, height)
+        } else if (layer.type === "image") {
+          const cached = cacheRef.current.get(layer.image)
+          if (cached && cached.complete) {
+            ctx.globalAlpha = layer.alpha ?? 1
+            ctx.drawImage(cached, 0, 0, width, height)
+          } else {
+            if (!cacheRef.current.has(layer.image)) {
+              const img = new Image()
+              img.src = layer.image
+              img.onload = () => draw()
+              cacheRef.current.set(layer.image, img)
+            }
+          }
+        }
+      }
+      ctx.globalAlpha = 1
+    }
+
+    draw()
+  }, [layers, width, height])
+
+  return <canvas ref={canvasRef} style={{ width: "100%", height: "100%" }} />
+}

--- a/src/components/LayerInspector.tsx
+++ b/src/components/LayerInspector.tsx
@@ -1,0 +1,72 @@
+import React from "react"
+import type { Layer } from "@lib/sceneSchema"
+
+type Props = {
+  layer: Layer | null
+  onChange(layer: Layer): void
+}
+
+function TransitionEditor({ label, value, onChange }: { label: string; value?: { type: string; duration?: number }; onChange(v?: { type: string; duration?: number }): void }) {
+  return (
+    <div style={{ marginTop: 4 }}>
+      <label>{label} type
+        <input
+          value={value?.type || ""}
+          onChange={e => {
+            const type = e.target.value
+            onChange(type ? { type, duration: value?.duration } : undefined)
+          }}
+        />
+      </label>
+      <label>
+        duration
+        <input
+          type="number"
+          value={value?.duration ?? ""}
+          onChange={e => {
+            const d = e.target.value
+            onChange(value ? { ...value, duration: d === "" ? undefined : parseFloat(d) } : { type: "", duration: parseFloat(d) })
+          }}
+        />
+      </label>
+    </div>
+  )
+}
+
+export default function LayerInspector({ layer, onChange }: Props) {
+  if (!layer) return null
+  return (
+    <div style={{ marginTop: 8 }}>
+      {layer.type === "image" && (
+        <label>Image
+          <input value={layer.image} onChange={e => onChange({ ...layer, image: e.target.value })} />
+        </label>
+      )}
+      {layer.type === "color" && (
+        <label>Color
+          <input type="color" value={layer.color} onChange={e => onChange({ ...layer, color: e.target.value })} />
+        </label>
+      )}
+      <label>Opacity
+        <input
+          type="number"
+          min={0}
+          max={1}
+          step={0.01}
+          value={layer.alpha}
+          onChange={e => onChange({ ...layer, alpha: parseFloat(e.target.value) })}
+        />
+      </label>
+      <TransitionEditor
+        label="Enter"
+        value={layer.enter_transition}
+        onChange={v => onChange({ ...layer, enter_transition: v })}
+      />
+      <TransitionEditor
+        label="Exit"
+        value={layer.exit_transition}
+        onChange={v => onChange({ ...layer, exit_transition: v })}
+      />
+    </div>
+  )
+}

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from "react"
+import type { Layer } from "@lib/sceneSchema"
+
+type Props = {
+  layers: Layer[]
+  selectedId?: string
+  onSelect(id: string): void
+  onAddImage(): void
+  onAddColor(): void
+  onReorder(from: number, to: number): void
+  onDelete(id: string): void
+  onCopy(id: string): void
+}
+
+export default function LayerPanel({ layers, selectedId, onSelect, onAddImage, onAddColor, onReorder, onDelete, onCopy }: Props) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null)
+
+  const sorted = [...layers].sort((a, b) => a.zorder - b.zorder)
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 4, marginBottom: 8 }}>
+        <button onClick={onAddImage}>+ Image Layer</button>
+        <button onClick={onAddColor}>+ Color Layer</button>
+      </div>
+      <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+        {sorted.map((layer, index) => (
+          <li
+            key={layer.id}
+            draggable
+            onDragStart={() => setDragIndex(index)}
+            onDragOver={e => e.preventDefault()}
+            onDrop={() => {
+              if (dragIndex !== null) {
+                onReorder(dragIndex, index)
+                setDragIndex(null)
+              }
+            }}
+            onContextMenu={e => {
+              e.preventDefault()
+              setMenu({ id: layer.id, x: e.clientX, y: e.clientY })
+            }}
+          >
+            <button
+              onClick={() => onSelect(layer.id)}
+              style={{
+                width: "100%",
+                textAlign: "left",
+                background: selectedId === layer.id ? "#def" : undefined,
+              }}
+            >
+              {layer.type === "image" ? layer.image || layer.id : layer.color}
+            </button>
+          </li>
+        ))}
+      </ul>
+      {menu && (
+        <ul
+          style={{
+            position: "fixed",
+            top: menu.y,
+            left: menu.x,
+            background: "#fff",
+            border: "1px solid #ccc",
+            padding: 4,
+            listStyle: "none",
+            margin: 0,
+          }}
+          onMouseLeave={() => setMenu(null)}
+        >
+          <li>
+            <button
+              onClick={() => {
+                onCopy(menu.id)
+                setMenu(null)
+              }}
+            >
+              Copy
+            </button>
+          </li>
+          <li>
+            <button
+              onClick={() => {
+                onDelete(menu.id)
+                setMenu(null)
+              }}
+            >
+              Delete
+            </button>
+          </li>
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState } from "react"
-import { SceneProject, emptyProject, validateSceneProject } from "@lib/sceneSchema"
+import { SceneProject, emptyProject, validateSceneProject, Layer } from "@lib/sceneSchema"
 import type { Point, Hotspot } from "@lib/sceneSchema"
 import { loadFileAsText, saveTextFile, round3, convertProjectCoordsMode } from "@lib/utils"
 import HotspotPanel from "./HotspotPanel"
 import { drawHotspot, hitTestHotspot, translateHotspot, moveVertexTo, setCircleRadius, insertVertex } from "./HotspotShape"
+import LayerPanel from "./LayerPanel"
+import LayerInspector from "./LayerInspector"
+import CanvasView from "./CanvasView"
 
 type Action = NonNullable<Hotspot['action']>
 type ActionType = Action['type']
@@ -16,6 +19,8 @@ export default function ScenesEditor() {
   const [drag, setDrag] = useState<{ hsIndex: number; mode: "move"|"vertex"|"radius"; vertexIndex?: number; prevX: number; prevY: number } | null>(null)
   const [selectedHs, setSelectedHs] = useState<number | null>(null)
   const [manualRes, setManualRes] = useState(false)
+  const [selectedLayerId, setSelectedLayerId] = useState<string | null>(null)
+  const [canvasSize, setCanvasSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
   const resolutions = [
     { label: "640x480", width: 640, height: 480 },
     { label: "800x600", width: 800, height: 600 },
@@ -43,12 +48,18 @@ export default function ScenesEditor() {
   }, [])
 
   useEffect(() => {
+    setSelectedHs(null)
+    setSelectedLayerId(null)
+  }, [activeSceneId])
+
+  useEffect(() => {
     const canvas = canvasRef.current
     const scene = proj.scenes.find(s => s.id === activeSceneId)
     if (!canvas || !scene) return
     const rect = canvas.getBoundingClientRect()
     canvas.width = rect.width
     canvas.height = rect.height
+    setCanvasSize({ width: canvas.width, height: canvas.height })
     const ctx = canvas.getContext("2d")!
     const W = canvas.width, H = canvas.height
     ctx.clearRect(0,0,W,H)
@@ -57,9 +68,6 @@ export default function ScenesEditor() {
     ctx.strokeStyle = "#e9e9e9"
     for (let x=0; x<W; x+=40) { ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,H); ctx.stroke() }
     for (let y=0; y<H; y+=40) { ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(W,y); ctx.stroke() }
-    // background hint
-    ctx.fillStyle = "#fafafa"
-    ctx.fillRect(0,0,W,H)
 
     // border of scene
     ctx.strokeStyle = "#bbb"
@@ -90,6 +98,70 @@ export default function ScenesEditor() {
     const out = JSON.stringify(proj, null, 2)
     saveTextFile(out, "scenes.json")
     setStatus("Экспортировано scenes.json")
+  }
+
+  function addImageLayer() {
+    const scene = proj.scenes.find(s => s.id === activeSceneId)
+    if (!scene) return
+    const id = "layer_" + Math.random().toString(36).slice(2,8)
+    const layers = [...scene.layers, { id, type: "image" as const, image: "", alpha: 1, zorder: scene.layers.length }]
+    const next = { ...proj, scenes: proj.scenes.map(s => s.id === scene.id ? { ...s, layers } : s) }
+    setProj(validateSceneProject(next))
+    setSelectedLayerId(id)
+  }
+
+  function addColorLayer() {
+    const scene = proj.scenes.find(s => s.id === activeSceneId)
+    if (!scene) return
+    const id = "layer_" + Math.random().toString(36).slice(2,8)
+    const layers = [...scene.layers, { id, type: "color" as const, color: "#000000", alpha: 1, zorder: scene.layers.length }]
+    const next = { ...proj, scenes: proj.scenes.map(s => s.id === scene.id ? { ...s, layers } : s) }
+    setProj(validateSceneProject(next))
+    setSelectedLayerId(id)
+  }
+
+  function updateLayer(id: string, layer: Layer) {
+    const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
+    if (sceneIndex < 0) return
+    const scene = proj.scenes[sceneIndex]
+    const layers = scene.layers.map(l => l.id === id ? layer : l).map((l,i) => ({ ...l, zorder: i }))
+    const next = { ...proj, scenes: proj.scenes.map((s,i)=> i===sceneIndex? { ...s, layers }: s) }
+    setProj(validateSceneProject(next))
+  }
+
+  function deleteLayer(id: string) {
+    const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
+    if (sceneIndex < 0) return
+    const scene = proj.scenes[sceneIndex]
+    const layers = scene.layers.filter(l => l.id !== id).map((l,i)=> ({ ...l, zorder: i }))
+    const next = { ...proj, scenes: proj.scenes.map((s,i)=> i===sceneIndex? { ...s, layers }: s) }
+    setProj(validateSceneProject(next))
+    if (selectedLayerId === id) setSelectedLayerId(null)
+  }
+
+  function copyLayer(id: string) {
+    const scene = proj.scenes.find(s => s.id === activeSceneId)
+    if (!scene) return
+    const layer = scene.layers.find(l => l.id === id)
+    if (!layer) return
+    const newId = id + "_copy"
+    const copy: Layer = { ...layer, id: newId }
+    const layers = [...scene.layers, { ...copy, zorder: scene.layers.length }]
+    const next = { ...proj, scenes: proj.scenes.map(s => s.id === scene.id ? { ...s, layers } : s) }
+    setProj(validateSceneProject(next))
+    setSelectedLayerId(newId)
+  }
+
+  function reorderLayers(from: number, to: number) {
+    const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
+    if (sceneIndex < 0) return
+    const scene = proj.scenes[sceneIndex]
+    const layers = [...scene.layers]
+    const [item] = layers.splice(from, 1)
+    layers.splice(to, 0, item)
+    const relabeled = layers.map((l,i)=> ({ ...l, zorder: i }))
+    const next = { ...proj, scenes: proj.scenes.map((s,i)=> i===sceneIndex? { ...s, layers: relabeled }: s) }
+    setProj(validateSceneProject(next))
   }
 
   function addRectHotspot() {
@@ -224,6 +296,7 @@ export default function ScenesEditor() {
   const activeScene = proj.scenes.find(s => s.id === activeSceneId)
 
   const activeHotspot = selectedHs !== null && activeScene ? activeScene.hotspots![selectedHs] : null
+  const activeLayer = activeScene?.layers.find(l => l.id === selectedLayerId) || null
 
   function handleSceneNameChange(name: string) {
     const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
@@ -286,20 +359,35 @@ export default function ScenesEditor() {
         <div style={{ marginTop: 12, fontSize:12, opacity:0.8 }}>{status}</div>
       </aside>
       <section style={{ display:"flex", alignItems:"center", justifyContent:"center" }}>
-        <canvas
-          ref={canvasRef}
-          width={960}
-          height={540}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          style={{ width:"100%", height:"100%", maxWidth: "calc(100vw - 580px)", aspectRatio: "16/9", border:"1px solid #ddd", background:"#fff" }}
-        />
+        <div style={{ width:"100%", height:"100%", maxWidth: "calc(100vw - 580px)", aspectRatio: "16/9", position:"relative", border:"1px solid #ddd", background:"#fff" }}>
+          <CanvasView layers={activeScene?.layers || []} width={canvasSize.width} height={canvasSize.height} />
+          <canvas
+            ref={canvasRef}
+            width={960}
+            height={540}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            style={{ position:"absolute", top:0, left:0, width:"100%", height:"100%" }}
+          />
+        </div>
       </section>
       <aside style={{ borderLeft:"1px solid #eee", padding:12, overflowY:"auto" }}>
         {activeScene && (
           <>
-            <strong>Параметры сцены</strong>
+            <strong>Слои</strong>
+            <LayerPanel
+              layers={activeScene.layers}
+              selectedId={selectedLayerId || undefined}
+              onSelect={id => setSelectedLayerId(id)}
+              onAddImage={addImageLayer}
+              onAddColor={addColorLayer}
+              onReorder={reorderLayers}
+              onDelete={deleteLayer}
+              onCopy={copyLayer}
+            />
+            <LayerInspector layer={activeLayer} onChange={l => updateLayer(l.id, l)} />
+            <strong style={{ marginTop:8, display:"block" }}>Параметры сцены</strong>
             <div style={{ display:"flex", flexDirection:"column", gap:4, marginBottom:8 }}>
               <label>Название
                 <input value={activeScene.name||""} onChange={e=>handleSceneNameChange(e.target.value)} />

--- a/src/lib/sceneSchema.ts
+++ b/src/lib/sceneSchema.ts
@@ -27,15 +27,33 @@ export const HotspotSchema = z.object({
   hidden: z.boolean().default(false)
 })
 
-const LayerImage = z.object({ id: z.string(), type: z.literal("image"), image: z.string(), zorder: z.number().default(0) })
-const LayerColor = z.object({ id: z.string(), type: z.literal("color"), color: z.string(), alpha: z.number().default(1), zorder: z.number().default(0) })
-const Layer = z.discriminatedUnion("type", [LayerImage, LayerColor])
+const LayerImage = z.object({
+  id: z.string(),
+  type: z.literal("image"),
+  image: z.string(),
+  alpha: z.number().default(1),
+  zorder: z.number().default(0),
+  enter_transition: Transition.optional(),
+  exit_transition: Transition.optional(),
+})
+
+const LayerColor = z.object({
+  id: z.string(),
+  type: z.literal("color"),
+  color: z.string(),
+  alpha: z.number().default(1),
+  zorder: z.number().default(0),
+  enter_transition: Transition.optional(),
+  exit_transition: Transition.optional(),
+})
+
+const LayerSchema = z.discriminatedUnion("type", [LayerImage, LayerColor])
 
 const Scene = z.object({
   id: z.string(),
   name: z.string().optional(),
   enter_transition: Transition.optional(),
-  layers: z.array(Layer).default([]),
+  layers: z.array(LayerSchema).default([]),
   hotspots: z.array(HotspotSchema).default([])
 })
 
@@ -52,6 +70,7 @@ export const SceneProjectSchema = z.object({
 
 export type SceneProject = z.infer<typeof SceneProjectSchema>
 export type Hotspot = z.infer<typeof HotspotSchema>
+export type Layer = z.infer<typeof LayerSchema>
 
 export function validateSceneProject(data: unknown): SceneProject {
   const parsed = SceneProjectSchema.parse(data)


### PR DESCRIPTION
## Summary
- add LayerPanel with drag-and-drop z-order, add/copy/delete
- add LayerInspector for layer properties and transitions
- render layers in CanvasView with image caching and integrate into ScenesEditor
- extend scene schema for layer alpha and transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899224645308333bb58ed12d7232820