### PR TITLE
test: fix typecheck warnings and document pitfalls

### DIFF
--- a/src/components/DialogEditor.test.tsx
+++ b/src/components/DialogEditor.test.tsx
@@ -1,0 +1,12 @@
+import ReactFlow from 'reactflow'
+
+/**
+ * В React Flow нет типизированного экспорта `__rf`,
+ * но тестам иногда требуется доступ к внутреннему хранилищу.
+ * Используем приведение к `any`, чтобы избежать TS2614,
+ * и не забывать, что этот внутренний API может измениться.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const store = (ReactFlow as any).__rf
+
+export default store

--- a/src/components/ScenesEditor.test.tsx
+++ b/src/components/ScenesEditor.test.tsx
@@ -1,0 +1,9 @@
+/**
+ * При прошлых запусках появлялась ошибка TS2304:
+ * "Cannot find name 'global'".
+ * Вместо `global` используем `globalThis`, который
+ * всегда определён и в браузере, и в Node.
+ */
+;(globalThis as any).fetch = () => Promise.resolve({ json: () => Promise.resolve({}) })
+
+export {}


### PR DESCRIPTION
## Summary
- fix DialogEditor test to access React Flow store without invalid import
- replace `global` with `globalThis` in ScenesEditor test

## Testing
- `npm run typecheck --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6899239208e483339632cbf163aad0b0