### PR TITLE
feat: add scene persistence with schema migration

### DIFF
--- a/src/components/ScenesEditor.test.tsx
+++ b/src/components/ScenesEditor.test.tsx
@@ -1,5 +1,15 @@
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@lib/utils', async () => {
+  const actual = await vi.importActual<any>('@lib/utils');
+  return {
+    ...actual,
+    loadFileAsText: vi.fn(),
+    saveTextFile: vi.fn(),
+  };
+});
+
 import ScenesEditor from './ScenesEditor';
 import { loadFileAsText, saveTextFile } from '@lib/utils';
 
@@ -38,16 +48,6 @@ describe('ScenesEditor hotspot cloning', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // ЧАСТЬ 2: тесты компонента ScenesEditor (импорт/экспорт и добавление хотспота)
 // ─────────────────────────────────────────────────────────────────────────────
-
-// mock utils
-vi.mock('@lib/utils', async () => {
-  const actual = await vi.importActual<any>('@lib/utils');
-  return {
-    ...actual,
-    loadFileAsText: vi.fn(),
-    saveTextFile: vi.fn(),
-  };
-});
 
 const sampleProject = {
   version: '1.0',
@@ -89,6 +89,7 @@ describe('ScenesEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCanvas();
+    localStorage.clear();
     global.fetch = vi.fn(() =>
       Promise.resolve({
         ok: true,
@@ -112,7 +113,7 @@ describe('ScenesEditor', () => {
   it('adds rect hotspot via panel (matches current UI)', async () => {
     const { getByText } = render(<ScenesEditor />);
     await waitFor(() => getByText('Загружен samples/scenes.json'));
-    fireEvent.click(getByText('+ Rect Hotspot'));
+    fireEvent.click(getByText('+ Rect'));
     await waitFor(() => getByText('Добавлен прямоугольный хотспот'));
   });
 

--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from "react"
 import { SceneProject, emptyProject, validateSceneProject, Layer } from "@lib/sceneSchema"
 import type { Point, Hotspot } from "@lib/sceneSchema"
-import { loadFileAsText, saveTextFile, round3, convertProjectCoordsMode } from "@lib/utils"
+import { round3, convertProjectCoordsMode } from "@lib/utils"
+import { importSceneProjectFromFile, exportSceneProjectToFile, saveProjectToStorage, loadProjectFromStorage, parseSceneProject } from "@lib/scenePersistence"
 import HotspotPanel from "./HotspotPanel"
 import { drawHotspot, hitTestHotspot, translateHotspot, moveVertexTo, setCircleRadius, insertVertex } from "./HotspotShape"
 import LayerPanel from "./LayerPanel"
@@ -32,14 +33,21 @@ export default function ScenesEditor() {
     { label: "1920x1080", width: 1920, height: 1080 },
   ]
 
-  // load sample on first run
+  // load from localStorage or sample on first run
   useEffect(() => {
+    const stored = loadProjectFromStorage()
+    if (stored) {
+      setProj(stored)
+      setActiveSceneId(stored.scenes[0]?.id)
+      setStatus("Загружен проект из localStorage")
+      return
+    }
     fetch("/samples/scenes.json")
       .then(r => r.ok ? r.text() : Promise.reject("no sample"))
       .then(text => {
         try {
           const json = JSON.parse(text)
-          const parsed = validateSceneProject(json)
+          const parsed = parseSceneProject(json)
           setProj(parsed)
           setActiveSceneId(parsed.scenes[0]?.id)
           setStatus("Загружен samples/scenes.json")
@@ -84,23 +92,39 @@ export default function ScenesEditor() {
   }, [proj, activeSceneId])
 
   function onImportClicked() {
-    loadFileAsText(".json").then(text => {
-      if (!text) return
+    importSceneProjectFromFile().then(parsed => {
+      if (!parsed) return
       try {
-        const parsed = validateSceneProject(JSON.parse(text))
         setProj(parsed)
         setActiveSceneId(parsed.scenes[0]?.id)
         setStatus("Импорт JSON выполнен")
       } catch (e:any) {
         setStatus("Ошибка валидации: " + e.message)
       }
+    }).catch((e:any) => {
+      setStatus("Ошибка валидации: " + e.message)
     })
   }
 
   function onExportClicked() {
-    const out = JSON.stringify(proj, null, 2)
-    saveTextFile(out, "scenes.json")
+    exportSceneProjectToFile(proj)
     setStatus("Экспортировано scenes.json")
+  }
+
+  function onSaveClicked() {
+    saveProjectToStorage(proj)
+    setStatus("Сохранено в localStorage")
+  }
+
+  function onLoadClicked() {
+    const loaded = loadProjectFromStorage()
+    if (loaded) {
+      setProj(loaded)
+      setActiveSceneId(loaded.scenes[0]?.id)
+      setStatus("Загружено из localStorage")
+    } else {
+      setStatus("Нет сохранённого проекта")
+    }
   }
 
   function addImageLayer() {
@@ -324,6 +348,8 @@ export default function ScenesEditor() {
         <div style={{ display:"flex", gap:8, marginBottom: 8, alignItems:"center" }}>
           <button onClick={onImportClicked}>Импорт JSON</button>
           <button onClick={onExportClicked}>Экспорт JSON</button>
+          <button onClick={onSaveClicked}>Сохранить</button>
+          <button onClick={onLoadClicked}>Загрузить</button>
           <button onClick={openPreview}>Превью</button>
           <label style={{ display:"flex", alignItems:"center", gap:4 }}>
             <input type="checkbox" checked={useWebGL} onChange={e=>setUseWebGL(e.target.checked)} />WebGL

--- a/src/lib/scenePersistence.ts
+++ b/src/lib/scenePersistence.ts
@@ -1,0 +1,39 @@
+import { SceneProject, validateSceneProject } from "@lib/sceneSchema";
+import { loadFileAsText, saveTextFile } from "@lib/utils";
+
+export const SCHEMA_VERSION = 1;
+
+export function parseSceneProject(data: any): SceneProject {
+  const version = data?.schema_version ?? 0;
+  const projectData = version === 1 ? data.project : data;
+  const validated = validateSceneProject(projectData);
+  return validated;
+}
+
+export async function importSceneProjectFromFile(): Promise<SceneProject | null> {
+  const text = await loadFileAsText(".json");
+  if (!text) return null;
+  const raw = JSON.parse(text);
+  return parseSceneProject(raw);
+}
+
+export function exportSceneProjectToFile(proj: SceneProject) {
+  const out = JSON.stringify({ schema_version: SCHEMA_VERSION, project: proj }, null, 2);
+  saveTextFile(out, "scenes.json");
+}
+
+export function saveProjectToStorage(proj: SceneProject) {
+  const out = { schema_version: SCHEMA_VERSION, project: proj };
+  localStorage.setItem("scenesProject", JSON.stringify(out));
+}
+
+export function loadProjectFromStorage(): SceneProject | null {
+  const text = localStorage.getItem("scenesProject");
+  if (!text) return null;
+  try {
+    const raw = JSON.parse(text);
+    return parseSceneProject(raw);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- move import/export logic into new `scenePersistence` module
- load scenes project from localStorage with schema migration
- add Save/Load controls and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689927b516308333953e45a42fed48af