### PR TITLE
feat: add hotspot inspector with validation

### DIFF
--- a/src/components/CanvasView.tsx
+++ b/src/components/CanvasView.tsx
@@ -147,8 +147,7 @@ export default function CanvasView(props: CanvasViewProps) {
         // Хотспоты
         if (project && scene) {
           for (const hs of hotspots) {
-            // @ts-expect-error optional domain-specific flag
-            if (!(hs as any).hidden) drawHotspotPreview(ctx2d, project, hs, W, H);
+            if (!hs.hidden) drawHotspotPreview(ctx2d, project, hs, W, H);
           }
         }
       } else {
@@ -178,8 +177,7 @@ export default function CanvasView(props: CanvasViewProps) {
         // Хотспоты
         if (project && scene) {
           for (const hs of hotspots) {
-            // @ts-expect-error optional domain-specific flag
-            if (!(hs as any).hidden) drawHotspotPreview(ctx, project, hs, W, H);
+            if (!hs.hidden) drawHotspotPreview(ctx, project, hs, W, H);
           }
         }
       }

--- a/src/components/DialogEditor.test.tsx
+++ b/src/components/DialogEditor.test.tsx
@@ -62,8 +62,10 @@ vi.mock('reactflow', async () => {
 })
 
 import DialogEditor from './DialogEditor'
-import { __rf } from 'reactflow'
+import * as ReactFlowModule from 'reactflow'
 import { validateDialogProject } from '@lib/dialogSchema'
+
+const __rf = (ReactFlowModule as any).__rf
 
 describe('DialogEditor', () => {
   it('addNode adds a node to project', () => {

--- a/src/components/HotspotContext.tsx
+++ b/src/components/HotspotContext.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from "react"
+import type { Hotspot } from "@lib/sceneSchema"
+
+type Ctx = { hotspot: Hotspot; setHotspot(hs: Hotspot): void }
+
+export const HotspotContext = createContext<Ctx | null>(null)
+
+export function useHotspot() {
+  const ctx = useContext(HotspotContext)
+  if (!ctx) throw new Error("HotspotContext not provided")
+  return ctx
+}

--- a/src/components/HotspotInspector.test.tsx
+++ b/src/components/HotspotInspector.test.tsx
@@ -1,0 +1,21 @@
+import { render, fireEvent, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import HotspotInspector from './HotspotInspector'
+import { HotspotContext } from './HotspotContext'
+import type { Hotspot } from '@lib/sceneSchema'
+
+describe('HotspotInspector', () => {
+  it('shows error for invalid expression', () => {
+    const hs: Hotspot = { id: 'h1', shape: 'rect', rect: { x: 0, y: 0, w: 1, h: 1 }, hidden: false }
+    const setHs = vi.fn()
+    render(
+      <HotspotContext.Provider value={{ hotspot: hs, setHotspot: setHs }}>
+        <HotspotInspector />
+      </HotspotContext.Provider>
+    )
+    const input = screen.getByLabelText('visible_if') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '(' } })
+    expect(screen.getByText(/Invalid expression/)).toBeInTheDocument()
+    expect(setHs).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/HotspotInspector.tsx
+++ b/src/components/HotspotInspector.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useState } from "react"
+import { Hotspot, HotspotSchema } from "@lib/sceneSchema"
+import { useHotspot } from "./HotspotContext"
+
+type Action = NonNullable<Hotspot['action']>
+type ActionType = Action['type']
+
+type Tab = 'basic' | 'actions' | 'transitions'
+
+export default function HotspotInspector() {
+  const { hotspot, setHotspot } = useHotspot()
+  const [tab, setTab] = useState<Tab>('basic')
+  const [form, setForm] = useState<Hotspot>(hotspot)
+  const [errors, setErrors] = useState<Record<string,string>>({})
+
+  useEffect(() => {
+    setForm(hotspot)
+    setErrors({})
+  }, [hotspot])
+
+  function update(part: Partial<Hotspot>) {
+    const next = { ...form, ...part }
+    setForm(next)
+    const parsed = HotspotSchema.safeParse(next)
+    if (parsed.success) {
+      setErrors({})
+      setHotspot(parsed.data)
+    } else {
+      const err: Record<string,string> = {}
+      for (const issue of parsed.error.issues) {
+        err[issue.path.join('.')] = issue.message
+      }
+      setErrors(err)
+    }
+  }
+
+  function updateAction(action: Hotspot['action']) {
+    update({ action })
+  }
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      <div style={{ display: 'flex', gap: 4, marginBottom: 8 }}>
+        <button onClick={() => setTab('basic')} style={{ fontWeight: tab === 'basic' ? 600 : 400 }}>Основные</button>
+        <button onClick={() => setTab('actions')} style={{ fontWeight: tab === 'actions' ? 600 : 400 }}>Действия</button>
+        <button onClick={() => setTab('transitions')} style={{ fontWeight: tab === 'transitions' ? 600 : 400 }}>Переходы</button>
+      </div>
+      {tab === 'basic' && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <label>tooltip
+            <input value={form.tooltip || ''} onChange={e => update({ tooltip: e.target.value || undefined })} />
+          </label>
+          <label>visible_if
+            <input value={form.visible_if || ''} onChange={e => update({ visible_if: e.target.value || undefined })} />
+          </label>
+          {errors['visible_if'] && <div style={{ color: 'red' }}>{errors['visible_if']}</div>}
+          <label>enabled_if
+            <input value={form.enabled_if || ''} onChange={e => update({ enabled_if: e.target.value || undefined })} />
+          </label>
+          {errors['enabled_if'] && <div style={{ color: 'red' }}>{errors['enabled_if']}</div>}
+        </div>
+      )}
+      {tab === 'actions' && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <label>action
+            <select value={form.action?.type || ''} onChange={e => {
+              const type = e.target.value as ActionType | ''
+              let action: Hotspot['action'] | undefined
+              switch (type) {
+                case 'go_scene':
+                  action = { type, scene_id: '' }
+                  break
+                case 'jump_label':
+                  action = { type, label: '' }
+                  break
+                case 'call_label':
+                  action = { type, label: '' }
+                  break
+                case 'call_screen':
+                  action = { type, screen: '' }
+                  break
+                case 'function':
+                  action = { type, name: '' }
+                  break
+                default:
+                  action = undefined
+              }
+              update({ action })
+            }}>
+              <option value="">none</option>
+              <option value="go_scene">go_scene</option>
+              <option value="jump_label">jump_label</option>
+              <option value="call_label">call_label</option>
+              <option value="call_screen">call_screen</option>
+              <option value="function">function</option>
+            </select>
+          </label>
+          {form.action?.type === 'go_scene' && (
+            <label>scene_id
+              <input value={form.action.scene_id} onChange={e => {
+                if (form.action?.type !== 'go_scene') return
+                updateAction({ ...form.action, scene_id: e.target.value })
+              }} />
+            </label>
+          )}
+          {form.action?.type === 'jump_label' && (
+            <label>label
+              <input value={form.action.label} onChange={e => {
+                if (form.action?.type !== 'jump_label') return
+                updateAction({ ...form.action, label: e.target.value })
+              }} />
+            </label>
+          )}
+          {form.action?.type === 'call_label' && (
+            <label>label
+              <input value={form.action.label} onChange={e => {
+                if (form.action?.type !== 'call_label') return
+                updateAction({ ...form.action, label: e.target.value })
+              }} />
+            </label>
+          )}
+          {form.action?.type === 'call_screen' && (
+            <label>screen
+              <input value={form.action.screen} onChange={e => {
+                if (form.action?.type !== 'call_screen') return
+                updateAction({ ...form.action, screen: e.target.value })
+              }} />
+            </label>
+          )}
+          {form.action?.type === 'function' && (
+            <label>name
+              <input value={form.action.name} onChange={e => {
+                if (form.action?.type !== 'function') return
+                updateAction({ ...form.action, name: e.target.value })
+              }} />
+            </label>
+          )}
+        </div>
+      )}
+      {tab === 'transitions' && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {form.action?.type === 'go_scene' ? (
+            <>
+              <label>type
+                <input value={form.action.transition?.type || ''} onChange={e => {
+                  if (form.action?.type !== 'go_scene') return
+                  const tr = { ...(form.action.transition || {}), type: e.target.value }
+                  updateAction({ ...form.action, transition: tr })
+                }} />
+              </label>
+              <label>duration
+                <input type="number" value={form.action.transition?.duration ?? ''} onChange={e => {
+                  if (form.action?.type !== 'go_scene') return
+                  const d = e.target.value
+                  const duration = d === '' ? undefined : parseFloat(d)
+                  const tr = { ...(form.action.transition || { type: '' }), duration, easing: form.action.transition?.easing }
+                  updateAction({ ...form.action, transition: tr })
+                }} />
+              </label>
+              {errors['action.transition.duration'] && <div style={{ color: 'red' }}>{errors['action.transition.duration']}</div>}
+              <label>easing
+                <input value={form.action.transition?.easing || ''} onChange={e => {
+                  if (form.action?.type !== 'go_scene') return
+                  const tr = { ...(form.action.transition || { type: '' }), easing: e.target.value }
+                  updateAction({ ...form.action, transition: tr })
+                }} />
+              </label>
+            </>
+          ) : (
+            <div>Нет переходов для этого действия</div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/LayerInspector.tsx
+++ b/src/components/LayerInspector.tsx
@@ -6,7 +6,7 @@ type Props = {
   onChange(layer: Layer): void
 }
 
-function TransitionEditor({ label, value, onChange }: { label: string; value?: { type: string; duration?: number }; onChange(v?: { type: string; duration?: number }): void }) {
+function TransitionEditor({ label, value, onChange }: { label: string; value?: { type: string; duration?: number; easing?: string }; onChange(v?: { type: string; duration?: number; easing?: string }): void }) {
   return (
     <div style={{ marginTop: 4 }}>
       <label>{label} type
@@ -14,7 +14,7 @@ function TransitionEditor({ label, value, onChange }: { label: string; value?: {
           value={value?.type || ""}
           onChange={e => {
             const type = e.target.value
-            onChange(type ? { type, duration: value?.duration } : undefined)
+            onChange(type ? { type, duration: value?.duration, easing: value?.easing } : undefined)
           }}
         />
       </label>
@@ -26,6 +26,16 @@ function TransitionEditor({ label, value, onChange }: { label: string; value?: {
           onChange={e => {
             const d = e.target.value
             onChange(value ? { ...value, duration: d === "" ? undefined : parseFloat(d) } : { type: "", duration: parseFloat(d) })
+          }}
+        />
+      </label>
+      <label>
+        easing
+        <input
+          value={value?.easing || ""}
+          onChange={e => {
+            const easing = e.target.value
+            onChange(value ? { ...value, easing } : { type: "", easing })
           }}
         />
       </label>

--- a/src/components/ScenesEditor.test.tsx
+++ b/src/components/ScenesEditor.test.tsx
@@ -89,7 +89,7 @@ describe('ScenesEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCanvas();
-    global.fetch = vi.fn(() =>
+    ;(globalThis as any).fetch = vi.fn(() =>
       Promise.resolve({
         ok: true,
         text: () => Promise.resolve(JSON.stringify(sampleProject)),
@@ -112,7 +112,7 @@ describe('ScenesEditor', () => {
   it('adds rect hotspot via panel (matches current UI)', async () => {
     const { getByText } = render(<ScenesEditor />);
     await waitFor(() => getByText('Загружен samples/scenes.json'));
-    fireEvent.click(getByText('+ Rect Hotspot'));
+    fireEvent.click(getByText('+ Rect'));
     await waitFor(() => getByText('Добавлен прямоугольный хотспот'));
   });
 

--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -7,9 +7,8 @@ import { drawHotspot, hitTestHotspot, translateHotspot, moveVertexTo, setCircleR
 import LayerPanel from "./LayerPanel"
 import LayerInspector from "./LayerInspector"
 import CanvasView from "./CanvasView"
-
-type Action = NonNullable<Hotspot['action']>
-type ActionType = Action['type']
+import HotspotInspector from "./HotspotInspector"
+import { HotspotContext } from "./HotspotContext"
 
 export default function ScenesEditor() {
   const [proj, setProj] = useState<SceneProject>(emptyProject())
@@ -468,81 +467,9 @@ export default function ScenesEditor() {
                     ))}
                   </div>
                 )}
-                <div style={{ marginTop:8 }}>
-                  <label>Tooltip
-                    <input value={activeHotspot.tooltip||""} onChange={e=>updateHotspot(selectedHs!, { ...activeHotspot, tooltip:e.target.value })} />
-                  </label>
-                </div>
-                <div style={{ marginTop:8 }}>
-                  <label>Action
-                    <select value={activeHotspot.action?.type||""} onChange={e=>{
-                      const type = e.target.value as ActionType
-                      let action: Hotspot['action'] = undefined
-                      switch (type) {
-                        case "go_scene":
-                          action = { type, scene_id: activeSceneId! }
-                          break
-                        case "jump_label":
-                          action = { type, label: "" }
-                          break
-                        case "call_label":
-                          action = { type, label: "" }
-                          break
-                        case "call_screen":
-                          action = { type, screen: "" }
-                          break
-                        case "function":
-                          action = { type, name: "" }
-                          break
-                        default:
-                          action = undefined
-                      }
-                      updateHotspot(selectedHs!, { ...activeHotspot, action })
-                    }}>
-                      <option value="">none</option>
-                      <option value="go_scene">go_scene</option>
-                      <option value="jump_label">jump_label</option>
-                      <option value="call_label">call_label</option>
-                      <option value="call_screen">call_screen</option>
-                      <option value="function">function</option>
-                    </select>
-                  </label>
-                  {activeHotspot.action?.type === "go_scene" && (
-                    <input value={activeHotspot.action.scene_id} onChange={e=>{
-                      if (activeHotspot.action?.type !== "go_scene") return
-                      const action = { ...activeHotspot.action, scene_id: e.target.value }
-                      updateHotspot(selectedHs!, { ...activeHotspot, action })
-                    }} />
-                  )}
-                  {activeHotspot.action?.type === "jump_label" && (
-                    <input value={activeHotspot.action.label} onChange={e=>{
-                      if (activeHotspot.action?.type !== "jump_label") return
-                      const action = { ...activeHotspot.action, label: e.target.value }
-                      updateHotspot(selectedHs!, { ...activeHotspot, action })
-                    }} />
-                  )}
-                  {activeHotspot.action?.type === "call_label" && (
-                    <input value={activeHotspot.action.label} onChange={e=>{
-                      if (activeHotspot.action?.type !== "call_label") return
-                      const action = { ...activeHotspot.action, label: e.target.value }
-                      updateHotspot(selectedHs!, { ...activeHotspot, action })
-                    }} />
-                  )}
-                  {activeHotspot.action?.type === "call_screen" && (
-                    <input value={activeHotspot.action.screen} onChange={e=>{
-                      if (activeHotspot.action?.type !== "call_screen") return
-                      const action = { ...activeHotspot.action, screen: e.target.value }
-                      updateHotspot(selectedHs!, { ...activeHotspot, action })
-                    }} />
-                  )}
-                  {activeHotspot.action?.type === "function" && (
-                    <input value={activeHotspot.action.name} onChange={e=>{
-                      if (activeHotspot.action?.type !== "function") return
-                      const action = { ...activeHotspot.action, name: e.target.value }
-                      updateHotspot(selectedHs!, { ...activeHotspot, action })
-                    }} />
-                  )}
-                </div>
+                <HotspotContext.Provider value={{ hotspot: activeHotspot, setHotspot: hs => updateHotspot(selectedHs!, hs) }}>
+                  <HotspotInspector />
+                </HotspotContext.Provider>
               </div>
             )}
           </>

--- a/src/lib/sceneSchema.test.ts
+++ b/src/lib/sceneSchema.test.ts
@@ -25,4 +25,17 @@ describe('sceneSchema', () => {
   it('rejects invalid data', () => {
     expect(() => validateSceneProject({ project: {} })).toThrow()
   })
+
+  it('rejects hotspot with invalid expressions', () => {
+    const proj = {
+      version: '1.0',
+      project: { reference_resolution: { width: 100, height: 50 }, coords_mode: 'relative' as const },
+      scenes: [{
+        id: 's1',
+        layers: [],
+        hotspots: [{ id: 'h1', shape: 'rect', rect: { x: 0, y: 0, w: 1, h: 1 }, visible_if: '(', hidden: false }],
+      }],
+    }
+    expect(() => validateSceneProject(proj)).toThrow()
+  })
 })

--- a/src/lib/sceneSchema.ts
+++ b/src/lib/sceneSchema.ts
@@ -5,7 +5,22 @@ export const Circle = z.object({ cx: z.number(), cy: z.number(), r: z.number() }
 export const PointSchema = z.tuple([z.number(), z.number()])
 export type Point = z.infer<typeof PointSchema>
 
-const Transition = z.object({ type: z.string(), duration: z.number().optional() })
+function exprValid(expr?: string): boolean {
+  if (!expr) return true
+  try {
+    // eslint-disable-next-line no-new-func
+    new Function(`return (${expr})`)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const Transition = z.object({
+  type: z.string(),
+  duration: z.number().optional(),
+  easing: z.string().optional(),
+})
 
 const Action = z.discriminatedUnion("type", [
   z.object({ type: z.literal("go_scene"), scene_id: z.string(), transition: Transition.optional() }),
@@ -23,6 +38,8 @@ export const HotspotSchema = z.object({
   circle: Circle.optional(),
   tooltip: z.string().optional(),
   hover_effect: z.record(z.any()).optional(),
+  visible_if: z.string().optional().refine(exprValid, { message: "Invalid expression" }),
+  enabled_if: z.string().optional().refine(exprValid, { message: "Invalid expression" }),
   action: Action.optional(),
   hidden: z.boolean().default(false)
 })


### PR DESCRIPTION
## Summary
- extend hotspot schema with conditional visibility/enabled and transition easing
- add HotspotInspector with tabs for basic properties, actions, and transitions
- connect inspector to active hotspot via context and validate fields

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689927a506ec833388e0bd81895b72ca