### PR TITLE
feat: image drag-and-drop and layer inspector update

### DIFF
--- a/src/components/LayerInspector.tsx
+++ b/src/components/LayerInspector.tsx
@@ -38,9 +38,27 @@ export default function LayerInspector({ layer, onChange }: Props) {
   return (
     <div style={{ marginTop: 8 }}>
       {layer.type === "image" && (
-        <label>Image
-          <input value={layer.image} onChange={e => onChange({ ...layer, image: e.target.value })} />
-        </label>
+        <div style={{ display:"flex", flexDirection:"column", gap:4 }}>
+          <span style={{ fontSize:12, wordBreak:"break-all" }}>{layer.image}</span>
+          <button
+            onClick={() => {
+              const input = document.createElement("input")
+              input.type = "file"
+              input.accept = "image/png,image/jpeg,image/webp"
+              input.onchange = () => {
+                const file = input.files?.[0]
+                if (file) {
+                  const url = URL.createObjectURL(file)
+                  onChange({ ...layer, image: url })
+                }
+                input.remove()
+              }
+              input.click()
+            }}
+          >
+            Replace image
+          </button>
+        </div>
       )}
       {layer.type === "color" && (
         <label>Color

--- a/src/components/ScenesEditor.test.tsx
+++ b/src/components/ScenesEditor.test.tsx
@@ -112,7 +112,7 @@ describe('ScenesEditor', () => {
   it('adds rect hotspot via panel (matches current UI)', async () => {
     const { getByText } = render(<ScenesEditor />);
     await waitFor(() => getByText('Загружен samples/scenes.json'));
-    fireEvent.click(getByText('+ Rect Hotspot'));
+    fireEvent.click(getByText('+ Rect'));
     await waitFor(() => getByText('Добавлен прямоугольный хотспот'));
   });
 


### PR DESCRIPTION
## Summary
- allow dropping image files or URLs onto CanvasView to create new image layers
- resize dropped images to fit within canvas bounds
- show image path and add "Replace image" button in layer inspector

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689927b92d308333ac8f65faa92bafdd