### PR TITLE
Fix hotspot button test to match current label

### DIFF
--- a/src/components/ScenesEditor.test.tsx
+++ b/src/components/ScenesEditor.test.tsx
@@ -112,7 +112,7 @@ describe('ScenesEditor', () => {
   it('adds rect hotspot via panel (matches current UI)', async () => {
     const { getByText } = render(<ScenesEditor />);
     await waitFor(() => getByText('Загружен samples/scenes.json'));
-    fireEvent.click(getByText('+ Rect Hotspot'));
+    fireEvent.click(getByText('+ Rect'));
     await waitFor(() => getByText('Добавлен прямоугольный хотспот'));
   });
 


### PR DESCRIPTION
## Summary
- update ScenesEditor test to click "+ Rect" button instead of outdated "+ Rect Hotspot"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899289149dc83338d48b734889b1818