### PR TITLE
fix: clean up type errors

### DIFF
--- a/src/components/CanvasView.tsx
+++ b/src/components/CanvasView.tsx
@@ -147,8 +147,7 @@ export default function CanvasView(props: CanvasViewProps) {
         // Хотспоты
         if (project && scene) {
           for (const hs of hotspots) {
-            // @ts-expect-error optional domain-specific flag
-            if (!(hs as any).hidden) drawHotspotPreview(ctx2d, project, hs, W, H);
+            if (!hs.hidden) drawHotspotPreview(ctx2d, project, hs, W, H);
           }
         }
       } else {
@@ -178,8 +177,7 @@ export default function CanvasView(props: CanvasViewProps) {
         // Хотспоты
         if (project && scene) {
           for (const hs of hotspots) {
-            // @ts-expect-error optional domain-specific flag
-            if (!(hs as any).hidden) drawHotspotPreview(ctx, project, hs, W, H);
+            if (!hs.hidden) drawHotspotPreview(ctx, project, hs, W, H);
           }
         }
       }

--- a/src/components/DialogEditor.test.tsx
+++ b/src/components/DialogEditor.test.tsx
@@ -62,8 +62,10 @@ vi.mock('reactflow', async () => {
 })
 
 import DialogEditor from './DialogEditor'
-import { __rf } from 'reactflow'
+import * as ReactFlowModule from 'reactflow'
 import { validateDialogProject } from '@lib/dialogSchema'
+
+const { __rf } = ReactFlowModule as any
 
 describe('DialogEditor', () => {
   it('addNode adds a node to project', () => {

--- a/src/components/ScenesEditor.test.tsx
+++ b/src/components/ScenesEditor.test.tsx
@@ -90,7 +90,7 @@ describe('ScenesEditor', () => {
     vi.clearAllMocks();
     mockCanvas();
     localStorage.clear();
-    global.fetch = vi.fn(() =>
+    ;(globalThis as any).fetch = vi.fn(() =>
       Promise.resolve({
         ok: true,
         text: () => Promise.resolve(JSON.stringify(sampleProject)),


### PR DESCRIPTION
## Summary
- drop unused `@ts-expect-error` flags in CanvasView and rely on `hidden` property
- avoid importing non-existent `__rf` type from `reactflow` in test
- use `globalThis.fetch` in ScenesEditor tests

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689929841f448333860124b539c6f625