### PR TITLE
Refactor toolbar layout, add save/load and image folder access

### DIFF
--- a/public/images/index.html
+++ b/public/images/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><title>Изображения</title></head>
+<body>
+<p>Здесь будут храниться изображения проекта.</p>
+</body></html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,33 @@
-import React, { useState } from "react"
-import ScenesEditor from "@components/ScenesEditor"
-import DialogEditor from "@components/DialogEditor"
+import React, { useRef, useState } from "react"
+import ScenesEditor, { ScenesEditorHandle } from "@components/ScenesEditor"
+import DialogEditor, { DialogEditorHandle } from "@components/DialogEditor"
 
 type Tab = "scenes" | "dialogs"
 
 export default function App() {
   const [tab, setTab] = useState<Tab>("scenes")
+  const scenesRef = useRef<ScenesEditorHandle>(null)
+  const dialogsRef = useRef<DialogEditorHandle>(null)
 
   return (
     <div style={{ fontFamily: "ui-sans-serif, system-ui, Arial", minHeight: "100vh", display: "flex", flexDirection: "column" }}>
-      <header style={{ padding: 12, borderBottom: "1px solid #eee", display: "flex", gap: 8, alignItems: "center" }}>
+      <header style={{ padding: 12, borderBottom: "1px solid #eee", display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
         <h1 style={{ margin: 0, fontSize: 18 }}>Ren'Py Content Editor</h1>
         <nav style={{ display: "flex", gap: 8, marginLeft: 16 }}>
           <button onClick={() => setTab("scenes")} aria-pressed={tab==="scenes"}>Сцены</button>
           <button onClick={() => setTab("dialogs")} aria-pressed={tab==="dialogs"}>Диалоги</button>
         </nav>
-        <div style={{ marginLeft: "auto", opacity: 0.7 }}>v0.1.0</div>
+        <div style={{ marginLeft: "auto", display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <button onClick={() => (tab === "scenes" ? scenesRef.current?.load() : dialogsRef.current?.load())}>Загрузить</button>
+          <button onClick={() => (tab === "scenes" ? scenesRef.current?.save() : dialogsRef.current?.save())}>Сохранить</button>
+          <button onClick={() => (tab === "scenes" ? scenesRef.current?.importJson() : dialogsRef.current?.importJson())}>Импорт JSON</button>
+          <button onClick={() => (tab === "scenes" ? scenesRef.current?.exportJson() : dialogsRef.current?.exportJson())}>Экспорт JSON</button>
+          <button onClick={() => window.open('/images/', '_blank')}>Папка с картинками</button>
+          <span style={{ opacity: 0.7 }}>v0.1.0</span>
+        </div>
       </header>
       <main style={{ flex: 1, display: "flex" }}>
-        {tab === "scenes" ? <ScenesEditor /> : <DialogEditor />}
+        {tab === "scenes" ? <ScenesEditor ref={scenesRef} /> : <DialogEditor ref={dialogsRef} />}
       </main>
       <footer style={{ padding: 8, borderTop: "1px solid #eee", fontSize: 12, opacity: 0.8 }}>
         JSON совместим со сцен-генератором и будущим генератором диалогов.

--- a/src/components/DialogEditor.tsx
+++ b/src/components/DialogEditor.tsx
@@ -1,10 +1,16 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useState, forwardRef, useImperativeHandle } from "react"
 import ReactFlow, { Background, Controls, MiniMap, addEdge, Connection, ReactFlowProvider, Node, Edge, useEdgesState, useNodesState } from "reactflow"
 import 'reactflow/dist/style.css'
 import { DialogProject, emptyDialogProject, validateDialogProject } from "@lib/dialogSchema"
 import { loadFileAsText, saveTextFile } from "@lib/utils"
+export interface DialogEditorHandle {
+  importJson: () => void
+  exportJson: () => void
+  save: () => void
+  load: () => void
+}
 
-function Graph() {
+const Graph = forwardRef<DialogEditorHandle>((props, ref) => {
   const [proj, setProj] = useState<DialogProject>(emptyDialogProject())
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([] as any)
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([] as any)
@@ -71,13 +77,36 @@ function Graph() {
     setStatus("Экспортирован dialogs.json")
   }
 
+  function save() {
+    localStorage.setItem("dialogProject", JSON.stringify(proj))
+    setStatus("Проект сохранён в браузере")
+  }
+
+  function load() {
+    const text = localStorage.getItem("dialogProject")
+    if (!text) {
+      setStatus("Нет сохранённого проекта")
+      return
+    }
+    try {
+      const parsed = validateDialogProject(JSON.parse(text))
+      setProj(parsed)
+      setStatus("Проект загружен из браузера")
+    } catch (e:any) {
+      setStatus("Ошибка: " + e.message)
+    }
+  }
+
+  useImperativeHandle(ref, () => ({
+    importJson,
+    exportJson,
+    save,
+    load,
+  }))
+
   return (
     <div style={{ display:"grid", gridTemplateColumns: "240px 1fr", width:"100%" }}>
       <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
-        <div style={{ display:"flex", gap:8, marginBottom: 8 }}>
-          <button onClick={importJson}>Импорт JSON</button>
-          <button onClick={exportJson}>Экспорт JSON</button>
-        </div>
         <button onClick={addNode}>+ Узел</button>
         <div style={{ marginTop: 12, fontSize:12, opacity:0.8 }}>{status}</div>
         <p style={{ fontSize:12, opacity:0.8 }}>Подсказка: соединяйте узлы линиями для создания переходов.</p>
@@ -91,12 +120,10 @@ function Graph() {
       </section>
     </div>
   )
-}
+})
 
-export default function DialogEditor(){
-  return (
-    <ReactFlowProvider>
-      <Graph />
-    </ReactFlowProvider>
-  )
-}
+export default forwardRef<DialogEditorHandle>((props, ref) => (
+  <ReactFlowProvider>
+    <Graph ref={ref} />
+  </ReactFlowProvider>
+))


### PR DESCRIPTION
## Summary
- Move JSON import/export to a shared header toolbar and add Save/Load actions
- Implement localStorage save/load in scene and dialog editors
- Add shortcut button to open the images folder

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68992c13a0748333a4edcef161270094