### PR TITLE
Refactor UI toolbar and add images folder access

### DIFF
--- a/src/components/DialogEditor.tsx
+++ b/src/components/DialogEditor.tsx
@@ -87,13 +87,13 @@ function Graph() {
   }
 
   return (
-    <div style={{ display:"grid", gridTemplateColumns: "240px 1fr", width:"100%" }}>
+    <div style={{ display:"grid", gridTemplateColumns: "240px 1fr", width:"100%", position:"relative" }}>
+      <div style={{ position:"absolute", top:8, right:8, display:"flex", gap:8 }}>
+        <button onClick={importJson}>Импорт JSON</button>
+        <button onClick={exportJson}>Экспорт JSON</button>
+      </div>
       <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
-        <div style={{ display:"flex", gap:8, marginBottom: 8 }}>
-          <button onClick={importJson}>Импорт JSON</button>
-          <button onClick={exportJson}>Экспорт JSON</button>
-        </div>
-        <button onClick={addNode}>+ Узел</button>
+        <button onClick={addNode} style={{ marginBottom:8 }}>+ Узел</button>
         <div style={{ marginTop: 12, fontSize:12, opacity:0.8 }}>{status}</div>
         <p style={{ fontSize:12, opacity:0.8 }}>Подсказка: соединяйте узлы линиями для создания переходов.</p>
       </aside>

--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -351,14 +351,21 @@ export default function ScenesEditor() {
     setPreview(false)
   }
 
+  function openImagesFolder() {
+    window.open("/images/", "_blank")
+  }
+
   return (
-    <div style={{ display:"grid", gridTemplateColumns: "280px 1fr 300px", width:"100%" }}>
+    <div style={{ display:"grid", gridTemplateColumns: "280px 1fr 300px", width:"100%", position:"relative" }}>
+      <div style={{ position:"absolute", top:8, right:8, display:"flex", gap:8 }}>
+        <button onClick={onImportClicked}>Импорт JSON</button>
+        <button onClick={onExportClicked}>Экспорт JSON</button>
+        <button onClick={onSaveClicked}>Сохранить</button>
+        <button onClick={onLoadClicked}>Загрузить</button>
+        <button onClick={openImagesFolder}>Папка изображений</button>
+      </div>
       <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
-        <div style={{ display:"flex", gap:8, marginBottom: 8, alignItems:"center" }}>
-          <button onClick={onImportClicked}>Импорт JSON</button>
-          <button onClick={onExportClicked}>Экспорт JSON</button>
-          <button onClick={onSaveClicked}>Сохранить</button>
-          <button onClick={onLoadClicked}>Загрузить</button>
+        <div style={{ display:"flex", gap:8, flexWrap:"wrap", marginBottom: 8, alignItems:"center" }}>
           <button onClick={openPreview}>Превью</button>
           <label style={{ display:"flex", alignItems:"center", gap:4 }}>
             <input type="checkbox" checked={useWebGL} onChange={e=>setUseWebGL(e.target.checked)} />WebGL


### PR DESCRIPTION
## Summary
- Move project JSON import/export and save/load controls to a new top-right toolbar and allow quick opening of the images folder
- Simplify editor sidebars and let control buttons wrap to avoid overlap
- Reposition dialog editor import/export controls into a top-right toolbar

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68992e39b4e08333ae11061dd86a8a14