### PR TITLE
Add project save/load panel

### DIFF
--- a/src/components/DialogEditor.tsx
+++ b/src/components/DialogEditor.tsx
@@ -71,27 +71,55 @@ function Graph() {
     setStatus("Экспортирован dialogs.json")
   }
 
-  return (
-    <div style={{ display:"grid", gridTemplateColumns: "240px 1fr", width:"100%" }}>
-      <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
-        <div style={{ display:"flex", gap:8, marginBottom: 8 }}>
+  function saveProject() {
+    try {
+      localStorage.setItem("dialogProject", JSON.stringify(proj))
+      setStatus("Проект сохранён")
+    } catch (e:any) {
+      setStatus("Не удалось сохранить проект: " + e.message)
+    }
+  }
+
+  function loadProject() {
+    const text = localStorage.getItem("dialogProject")
+    if (!text) {
+      setStatus("Нет сохранённого проекта")
+      return
+    }
+    try {
+      const parsed = validateDialogProject(JSON.parse(text))
+      setProj(parsed)
+      setStatus("Проект загружен")
+    } catch (e:any) {
+      setStatus("Ошибка загрузки: " + e.message)
+    }
+  }
+
+    return (
+      <>
+        <div style={{ display:"grid", gridTemplateColumns: "240px 1fr", width:"100%" }}>
+          <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
+            <button onClick={addNode}>+ Узел</button>
+            <div style={{ marginTop: 12, fontSize:12, opacity:0.8 }}>{status}</div>
+            <p style={{ fontSize:12, opacity:0.8 }}>Подсказка: соединяйте узлы линиями для создания переходов.</p>
+          </aside>
+          <section style={{ position:"relative", height: "calc(100vh - 100px)" }}>
+            <ReactFlow nodes={nodes} edges={edges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} fitView>
+              <MiniMap />
+              <Controls />
+              <Background />
+            </ReactFlow>
+          </section>
+        </div>
+        <div style={{ position: "fixed", left: 12, bottom: 12, display: "flex", flexDirection: "column", gap: 4 }}>
+          <button onClick={saveProject}>Сохранить</button>
+          <button onClick={loadProject}>Загрузить</button>
           <button onClick={importJson}>Импорт JSON</button>
           <button onClick={exportJson}>Экспорт JSON</button>
         </div>
-        <button onClick={addNode}>+ Узел</button>
-        <div style={{ marginTop: 12, fontSize:12, opacity:0.8 }}>{status}</div>
-        <p style={{ fontSize:12, opacity:0.8 }}>Подсказка: соединяйте узлы линиями для создания переходов.</p>
-      </aside>
-      <section style={{ position:"relative", height: "calc(100vh - 100px)" }}>
-        <ReactFlow nodes={nodes} edges={edges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} fitView>
-          <MiniMap />
-          <Controls />
-          <Background />
-        </ReactFlow>
-      </section>
-    </div>
-  )
-}
+      </>
+    )
+  }
 
 export default function DialogEditor(){
   return (

--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -81,6 +81,31 @@ export default function ScenesEditor() {
     setStatus("Экспортировано scenes.json")
   }
 
+  function saveProject() {
+    try {
+      localStorage.setItem("scenesProject", JSON.stringify(proj))
+      setStatus("Проект сохранён")
+    } catch (e:any) {
+      setStatus("Не удалось сохранить проект: " + e.message)
+    }
+  }
+
+  function loadProject() {
+    const text = localStorage.getItem("scenesProject")
+    if (!text) {
+      setStatus("Нет сохранённого проекта")
+      return
+    }
+    try {
+      const parsed = validateSceneProject(JSON.parse(text))
+      setProj(parsed)
+      setActiveSceneId(parsed.scenes[0]?.id)
+      setStatus("Проект загружен")
+    } catch (e:any) {
+      setStatus("Ошибка загрузки: " + e.message)
+    }
+  }
+
   function addRectHotspot() {
     const scene = proj.scenes.find(s => s.id === activeSceneId)
     if (!scene) return
@@ -102,22 +127,26 @@ export default function ScenesEditor() {
   )), [proj, activeSceneId])
 
   return (
-    <div style={{ display:"grid", gridTemplateColumns: "280px 1fr", width:"100%" }}>
-      <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
-        <div style={{ display:"flex", gap:8, marginBottom: 8 }}>
-          <button onClick={onImportClicked}>Импорт JSON</button>
-          <button onClick={onExportClicked}>Экспорт JSON</button>
-        </div>
-        <div style={{ display:"flex", gap:8, marginBottom: 8 }}>
-          <button onClick={addRectHotspot}>+ Rect Hotspot</button>
-        </div>
-        <strong>Сцены</strong>
-        <ul style={{ listStyle:"none", padding:0 }}>{sceneList}</ul>
-        <div style={{ marginTop: 12, fontSize:12, opacity:0.8 }}>{status}</div>
-      </aside>
-      <section style={{ display:"flex", alignItems:"center", justifyContent:"center" }}>
-        <canvas ref={canvasRef} width={960} height={540} style={{ width:"100%", height:"100%", maxWidth: "calc(100vw - 280px)", aspectRatio: "16/9", border:"1px solid #ddd", background:"#fff" }} />
-      </section>
-    </div>
+    <>
+      <div style={{ display:"grid", gridTemplateColumns: "280px 1fr", width:"100%" }}>
+        <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
+          <div style={{ display:"flex", gap:8, marginBottom: 8 }}>
+            <button onClick={addRectHotspot}>+ Rect Hotspot</button>
+          </div>
+          <strong>Сцены</strong>
+          <ul style={{ listStyle:"none", padding:0 }}>{sceneList}</ul>
+          <div style={{ marginTop: 12, fontSize:12, opacity:0.8 }}>{status}</div>
+        </aside>
+        <section style={{ display:"flex", alignItems:"center", justifyContent:"center" }}>
+          <canvas ref={canvasRef} width={960} height={540} style={{ width:"100%", height:"100%", maxWidth: "calc(100vw - 280px)", aspectRatio: "16/9", border:"1px solid #ddd", background:"#fff" }} />
+        </section>
+      </div>
+      <div style={{ position: "fixed", left: 12, bottom: 12, display: "flex", flexDirection: "column", gap: 4 }}>
+        <button onClick={saveProject}>Сохранить</button>
+        <button onClick={loadProject}>Загрузить</button>
+        <button onClick={onImportClicked}>Импорт JSON</button>
+        <button onClick={onExportClicked}>Экспорт JSON</button>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Move JSON import/export to a fixed control panel with Save/Load buttons
- Implement localStorage saveProject/loadProject helpers for scene and dialog editors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6899314a137c8333a696155422c02741