### PR TITLE
Refactor editor action button layouts

### DIFF
--- a/src/components/DialogEditor.tsx
+++ b/src/components/DialogEditor.tsx
@@ -107,7 +107,7 @@ function Graph() {
 
   return (
     <div style={{ display:"grid", gridTemplateColumns: "240px 1fr", width:"100%", position:"relative" }}>
-      <div style={{ position:"absolute", top:8, right:8, display:"flex", gap:8 }}>
+      <div style={{ position:"absolute", bottom:8, left:8, display:"flex", gap:8 }}>
         <button onClick={importJson}>Импорт JSON</button>
         <button onClick={exportJson}>Экспорт JSON</button>
       </div>

--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -402,18 +402,22 @@ export default function ScenesEditor() {
     setPreview(false)
   }
 
-  function openImagesFolder() {
-    window.open("/images/", "_blank")
-  }
-
   return (
     <div style={{ display:"grid", gridTemplateColumns: "280px 1fr 300px", width:"100%", position:"relative" }}>
-      <div style={{ position:"absolute", top:8, right:8, display:"flex", gap:8 }}>
-        <button onClick={onImportClicked}>Импорт JSON</button>
-        <button onClick={onExportClicked}>Экспорт JSON</button>
+      <div
+        style={{
+          position: "absolute",
+          bottom: 8,
+          left: 8,
+          display: "grid",
+          gridTemplateColumns: "repeat(2, auto)",
+          gap: 8,
+        }}
+      >
         <button onClick={onSaveClicked}>Сохранить</button>
         <button onClick={onLoadClicked}>Загрузить</button>
-        <button onClick={openImagesFolder}>Папка изображений</button>
+        <button onClick={onImportClicked}>Импорт JSON</button>
+        <button onClick={onExportClicked}>Экспорт JSON</button>
       </div>
       <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
         <div style={{ display:"flex", gap:8, flexWrap:"wrap", marginBottom: 8, alignItems:"center" }}>


### PR DESCRIPTION
## Summary
- Rework ScenesEditor action buttons into a bottom-left 2×2 grid (Save/Load over Import/Export) and drop image folder shortcut
- Move DialogEditor import/export controls to the bottom-left corner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689933b0d4d4833395a69c64f8643f0e