### PR TITLE
chore: add husky pre-commit with lint and tests

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+  }
+
+  readonly hook="$0"
+  readonly husky_dir="$(dirname -- "$hook")"
+
+  debug "starting $hook"
+  if [ "$HUSKY" = "skip" ]; then
+    debug "HUSKY env variable is set to skip, skipping hook"
+    exit 0
+  fi
+
+  readonly husky_skip_init=1
+  export husky_skip_init
+
+  sh -e "$husky_dir/../../node_modules/husky/lib/bin.js" "$hook" "$@"
+  exitCode="$?"
+
+  if [ "$exitCode" != 0 ]; then
+    echo "husky - $hook failed (exit code $exitCode)"
+  fi
+
+  exit "$exitCode"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged && npm run lint && npm test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview",
     "typecheck": "tsc -b --pretty",
     "lint": "echo \"(add eslint if needed)\"",
-    "test": "vitest run"
+    "test": "vitest run",
+    "format": "prettier --write .",
+    "prepare": "husky"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -26,6 +28,12 @@
     "typescript": "^5.5.4",
     "vitest": "^1.6.0",
     "vite": "^5.4.0",
-    "@vitejs/plugin-react": "^4.3.1"
+    "@vitejs/plugin-react": "^4.3.1",
+    "husky": "^9.0.0",
+    "lint-staged": "^15.2.5",
+    "prettier": "^3.3.2"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,css,html,json,md}": "prettier --write"
   }
 }


### PR DESCRIPTION
## Summary
- add Husky pre-commit hook running lint, tests, and lint-staged
- configure lint-staged to format staged files with Prettier
- add supporting scripts and dependencies

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f9519250833395509ceaef5d3984