### PR TITLE
feat: centralize editor state with undo/redo store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "reactflow": "^11.10.1",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zustand": "^4.5.7"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "zod": "^3.23.8",
-    "reactflow": "^11.10.1"
+    "reactflow": "^11.10.1",
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/components/DialogEditor.test.tsx
+++ b/src/components/DialogEditor.test.tsx
@@ -1,5 +1,5 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act } from 'react-dom/test-utils'
 
 vi.mock('@core/utils', () => ({
@@ -63,12 +63,18 @@ vi.mock('reactflow', async () => {
 
 import DialogEditor from './DialogEditor'
 import * as ReactFlowModule from 'reactflow'
+import { useDialogStore } from '../store'
+import { emptyDialogProject } from '@core/dialogSchema'
 
 
 const __rf = (ReactFlowModule as any).__rf
 
 
 describe('DialogEditor', () => {
+  beforeEach(() => {
+    useDialogStore.getState().resetProj(emptyDialogProject())
+  })
+
   it('addNode adds a node to project', async () => {
     const { getByText } = render(<DialogEditor />)
     fireEvent.click(getByText('+ Узел'))

--- a/src/components/DialogEditor.tsx
+++ b/src/components/DialogEditor.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react"
 import ReactFlow, { Background, Controls, MiniMap, addEdge, Connection, ReactFlowProvider, Node, Edge, useEdgesState, useNodesState } from "reactflow"
 import 'reactflow/dist/style.css'
-import { DialogProject, emptyDialogProject, validateDialogProject } from "@core/dialogSchema"
+import { validateDialogProject, type DialogProject } from "@core/dialogSchema"
 import { loadFileAsText, saveTextFile } from "@core/utils"
-import { useUndoState } from "@core/useUndo"
+import { useDialogStore } from "../store"
 
 interface DialogNodeData {
   label: string
@@ -15,7 +15,10 @@ type DialogNode = Node<DialogNodeData>
 type DialogEdge = Edge<DialogEdgeData>
 
 function Graph() {
-  const [proj, setProj, _resetProj, undo, redo] = useUndoState<DialogProject>(emptyDialogProject(), validateDialogProject)
+  const proj = useDialogStore(s => s.proj)
+  const setProj = useDialogStore(s => s.setProj)
+  const undo = useDialogStore(s => s.undo)
+  const redo = useDialogStore(s => s.redo)
   const [nodes, setNodes, onNodesChange] = useNodesState<DialogNodeData>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<DialogEdgeData>([])
   const [status, setStatus] = useState("")

--- a/src/components/ScenesEditor.test.tsx
+++ b/src/components/ScenesEditor.test.tsx
@@ -12,6 +12,8 @@ vi.mock('@core/utils', async () => {
 
 import ScenesEditor from './ScenesEditor';
 import { loadFileAsText, saveTextFile } from '@core/utils';
+import { useSceneStore } from '../store';
+import { emptyProject } from '@core/sceneSchema';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ЧАСТЬ 1: тест клонирования хотспота (structuredClone)
@@ -91,6 +93,8 @@ describe('ScenesEditor', () => {
     mockCanvas();
 
     localStorage.clear();
+
+    useSceneStore.getState().resetProj(emptyProject());
 
     ;(globalThis as any).fetch = vi.fn(() =>
       Promise.resolve({

--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react"
-import { SceneProject, emptyProject, validateSceneProject, Layer } from "@core/sceneSchema"
-import { useUndoState } from "@core/useUndo"
-import type { Point, Hotspot } from "@core/sceneSchema"
+import { Layer, type Point, type Hotspot } from "@core/sceneSchema"
+import { useSceneStore } from "../store"
 import { round3, convertProjectCoordsMode } from "@core/utils"
 import { importSceneProjectFromFile, exportSceneProjectToFile, saveProjectToStorage, loadProjectFromStorage, parseSceneProject } from "@core/scenePersistence"
 import HotspotPanel from "./HotspotPanel"
@@ -13,7 +12,11 @@ import HotspotInspector from "./HotspotInspector"
 import { HotspotContext } from "./HotspotContext"
 
 export default function ScenesEditor() {
-  const [proj, setProj, resetProj, undo, redo] = useUndoState<SceneProject>(emptyProject(), validateSceneProject)
+  const proj = useSceneStore(s => s.proj)
+  const setProj = useSceneStore(s => s.setProj)
+  const resetProj = useSceneStore(s => s.resetProj)
+  const undo = useSceneStore(s => s.undo)
+  const redo = useSceneStore(s => s.redo)
   const [status, setStatus] = useState<string>("")
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [activeSceneId, setActiveSceneId] = useState<string | undefined>(undefined)

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,67 @@
+import { create } from "zustand";
+import {
+  SceneProject,
+  emptyProject,
+  validateSceneProject,
+} from "@core/sceneSchema";
+import {
+  DialogProject,
+  emptyDialogProject,
+  validateDialogProject,
+} from "@core/dialogSchema";
+
+interface UndoState<T> {
+  proj: T;
+  undoStack: T[];
+  redoStack: T[];
+  setProj: (value: T | ((prev: T) => T)) => void;
+  resetProj: (value: T) => void;
+  undo: () => void;
+  redo: () => void;
+}
+
+function createUndoStore<T>(initial: T, validate: (v: T) => T) {
+  return create<UndoState<T>>((set, get) => ({
+    proj: validate(initial),
+    undoStack: [],
+    redoStack: [],
+    setProj: (value) =>
+      set((state) => {
+        const prev = state.proj;
+        const next =
+          typeof value === "function" ? (value as (p: T) => T)(prev) : value;
+        return {
+          proj: validate(next),
+          undoStack: [...state.undoStack, prev],
+          redoStack: [],
+        };
+      }),
+    resetProj: (value) =>
+      set({ proj: validate(value), undoStack: [], redoStack: [] }),
+    undo: () =>
+      set((state) => {
+        const prev = state.undoStack[state.undoStack.length - 1];
+        if (prev === undefined) return state;
+        const undoStack = state.undoStack.slice(0, -1);
+        const redoStack = [...state.redoStack, state.proj];
+        return { proj: prev, undoStack, redoStack };
+      }),
+    redo: () =>
+      set((state) => {
+        const next = state.redoStack[state.redoStack.length - 1];
+        if (next === undefined) return state;
+        const redoStack = state.redoStack.slice(0, -1);
+        const undoStack = [...state.undoStack, state.proj];
+        return { proj: next, undoStack, redoStack };
+      }),
+  }));
+}
+
+export const useSceneStore = createUndoStore<SceneProject>(
+  emptyProject(),
+  validateSceneProject,
+);
+export const useDialogStore = createUndoStore<DialogProject>(
+  emptyDialogProject(),
+  validateDialogProject,
+);


### PR DESCRIPTION
## Summary
- install zustand in frontend app
- centralize scene and dialog state with undo/redo history
- migrate ScenesEditor and DialogEditor to the new stores

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0b492e908333bbf56c52229b5dbd