### PR TITLE
feat: use API service for scenes and simplify editors

### DIFF
--- a/src/components/DialogEditor.test.tsx
+++ b/src/components/DialogEditor.test.tsx
@@ -1,96 +1,99 @@
-import { render, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { act } from 'react-dom/test-utils'
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act } from "react-dom/test-utils";
 
-vi.mock('@core/utils', () => ({
-  loadFileAsText: vi.fn(),
-  saveTextFile: vi.fn()
-}))
-
-vi.mock('@core/dialogSchema', async () => {
-  const actual = await vi.importActual<any>('@core/dialogSchema')
+vi.mock("@core/dialogSchema", async () => {
+  const actual = await vi.importActual<any>("@core/dialogSchema");
   return {
     ...actual,
-    validateDialogProject: vi.fn((p: any) => p)
-  }
-})
+    validateDialogProject: vi.fn((p: any) => p),
+  };
+});
 
-vi.mock('reactflow', async () => {
-  const React = await vi.importActual<any>('react')
-  let onConnect: any = null
-  let nodesStore: any[] = []
-  let edgesStore: any[] = []
+vi.mock("reactflow", async () => {
+  const React = await vi.importActual<any>("react");
+  let onConnect: any = null;
+  let nodesStore: any[] = [];
+  let edgesStore: any[] = [];
   const __rf = {
     getOnConnect: () => onConnect,
     getNodes: () => nodesStore,
-    getEdges: () => edgesStore
-  }
+    getEdges: () => edgesStore,
+  };
   function useNodesState(initial: any) {
-    const [nodes, setNodes] = React.useState(initial)
-    nodesStore = nodes
+    const [nodes, setNodes] = React.useState(initial);
+    nodesStore = nodes;
     const wrappedSet = (updater: any) => {
       setNodes((prev: any) => {
-        const val = typeof updater === 'function' ? updater(prev) : updater
-        nodesStore = val
-        return val
-      })
-    }
-    return [nodes, wrappedSet, () => {}]
+        const val = typeof updater === "function" ? updater(prev) : updater;
+        nodesStore = val;
+        return val;
+      });
+    };
+    return [nodes, wrappedSet, () => {}];
   }
   function useEdgesState(initial: any) {
-    const [edges, setEdges] = React.useState(initial)
-    edgesStore = edges
+    const [edges, setEdges] = React.useState(initial);
+    edgesStore = edges;
     const wrappedSet = (updater: any) => {
       setEdges((prev: any) => {
-        const val = typeof updater === 'function' ? updater(prev) : updater
-        edgesStore = val
-        return val
-      })
-    }
-    return [edges, wrappedSet, () => {}]
+        const val = typeof updater === "function" ? updater(prev) : updater;
+        edgesStore = val;
+        return val;
+      });
+    };
+    return [edges, wrappedSet, () => {}];
   }
-  const addEdge = (edge: any, edges: any[]) => [...edges, edge]
-  const ReactFlowProvider = ({ children }: any) => <div>{children}</div>
-  const Background = () => null
-  const Controls = () => null
-  const MiniMap = () => null
+  const addEdge = (edge: any, edges: any[]) => [...edges, edge];
+  const ReactFlowProvider = ({ children }: any) => <div>{children}</div>;
+  const Background = () => null;
+  const Controls = () => null;
+  const MiniMap = () => null;
   function ReactFlow(props: any) {
-    onConnect = props.onConnect
-    return <div>{props.children}</div>
+    onConnect = props.onConnect;
+    return <div>{props.children}</div>;
   }
-  return { default: ReactFlow, ReactFlowProvider, Background, Controls, MiniMap, useNodesState, useEdgesState, addEdge, __rf }
-})
+  return {
+    default: ReactFlow,
+    ReactFlowProvider,
+    Background,
+    Controls,
+    MiniMap,
+    useNodesState,
+    useEdgesState,
+    addEdge,
+    __rf,
+  };
+});
 
-import DialogEditor from './DialogEditor'
-import * as ReactFlowModule from 'reactflow'
-import { useDialogStore } from '../store'
-import { emptyDialogProject } from '@core/dialogSchema'
+import DialogEditor from "./DialogEditor";
+import * as ReactFlowModule from "reactflow";
+import { useDialogStore } from "../store";
+import { emptyDialogProject } from "@core/dialogSchema";
 
+const __rf = (ReactFlowModule as any).__rf;
 
-const __rf = (ReactFlowModule as any).__rf
-
-
-describe('DialogEditor', () => {
+describe("DialogEditor", () => {
   beforeEach(() => {
-    useDialogStore.getState().resetProj(emptyDialogProject())
-  })
+    useDialogStore.getState().resetProj(emptyDialogProject());
+  });
 
-  it('addNode adds a node to project', async () => {
-    const { getByText } = render(<DialogEditor />)
-    fireEvent.click(getByText('+ Узел'))
-    await waitFor(() => expect(__rf.getNodes().length).toBe(1))
-  })
+  it("addNode adds a node to project", async () => {
+    const { getByText } = render(<DialogEditor />);
+    fireEvent.click(getByText("+ Узел"));
+    await waitFor(() => expect(__rf.getNodes().length).toBe(1));
+  });
 
-  it('onConnect adds transition and edge', async () => {
-    const { getByText } = render(<DialogEditor />)
-    fireEvent.click(getByText('+ Узел'))
-    fireEvent.click(getByText('+ Узел'))
-    await waitFor(() => expect(__rf.getNodes().length).toBe(2))
-    const [n1, n2] = __rf.getNodes()
+  it("onConnect adds transition and edge", async () => {
+    const { getByText } = render(<DialogEditor />);
+    fireEvent.click(getByText("+ Узел"));
+    fireEvent.click(getByText("+ Узел"));
+    await waitFor(() => expect(__rf.getNodes().length).toBe(2));
+    const [n1, n2] = __rf.getNodes();
     act(() => {
-      __rf.getOnConnect()({ source: n1.id, target: n2.id })
-    })
-    await waitFor(() => expect(__rf.getEdges().length).toBe(1))
-    expect(__rf.getEdges()[0]).toMatchObject({ source: n1.id, target: n2.id })
-  })
-})
+      __rf.getOnConnect()({ source: n1.id, target: n2.id });
+    });
+    await waitFor(() => expect(__rf.getEdges().length).toBe(1));
+    expect(__rf.getEdges()[0]).toMatchObject({ source: n1.id, target: n2.id });
+  });
+});

--- a/src/components/DialogEditor.tsx
+++ b/src/components/DialogEditor.tsx
@@ -1,139 +1,179 @@
-import React, { useEffect, useState } from "react"
-import ReactFlow, { Background, Controls, MiniMap, addEdge, Connection, ReactFlowProvider, Node, Edge, useEdgesState, useNodesState } from "reactflow"
-import 'reactflow/dist/style.css'
-import { validateDialogProject, type DialogProject } from "@core/dialogSchema"
-import { loadFileAsText, saveTextFile } from "@core/utils"
-import { useDialogStore } from "../store"
+import React, { useEffect, useState } from "react";
+import ReactFlow, {
+  Background,
+  Controls,
+  MiniMap,
+  addEdge,
+  Connection,
+  ReactFlowProvider,
+  Node,
+  Edge,
+  useEdgesState,
+  useNodesState,
+} from "reactflow";
+import "reactflow/dist/style.css";
+import { validateDialogProject, type DialogProject } from "@core/dialogSchema";
+import { useDialogStore } from "../store";
 
 interface DialogNodeData {
-  label: string
+  label: string;
 }
 
 interface DialogEdgeData {}
 
-type DialogNode = Node<DialogNodeData>
-type DialogEdge = Edge<DialogEdgeData>
+type DialogNode = Node<DialogNodeData>;
+type DialogEdge = Edge<DialogEdgeData>;
 
 function Graph() {
-  const proj = useDialogStore(s => s.proj)
-  const setProj = useDialogStore(s => s.setProj)
-  const undo = useDialogStore(s => s.undo)
-  const redo = useDialogStore(s => s.redo)
-  const [nodes, setNodes, onNodesChange] = useNodesState<DialogNodeData>([])
-  const [edges, setEdges, onEdgesChange] = useEdgesState<DialogEdgeData>([])
-  const [status, setStatus] = useState("")
+  const proj = useDialogStore((s) => s.proj);
+  const setProj = useDialogStore((s) => s.setProj);
+  const undo = useDialogStore((s) => s.undo);
+  const redo = useDialogStore((s) => s.redo);
+  const [nodes, setNodes, onNodesChange] = useNodesState<DialogNodeData>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<DialogEdgeData>([]);
+  const [status, setStatus] = useState("");
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "z" && !e.shiftKey) {
-        e.preventDefault()
-        undo()
-      } else if ((e.ctrlKey || e.metaKey) && (e.key.toLowerCase() === "y" || (e.shiftKey && e.key.toLowerCase() === "z"))) {
-        e.preventDefault()
-        redo()
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        e.key.toLowerCase() === "z" &&
+        !e.shiftKey
+      ) {
+        e.preventDefault();
+        undo();
+      } else if (
+        (e.ctrlKey || e.metaKey) &&
+        (e.key.toLowerCase() === "y" ||
+          (e.shiftKey && e.key.toLowerCase() === "z"))
+      ) {
+        e.preventDefault();
+        redo();
       }
-    }
-    window.addEventListener("keydown", handler)
-    return () => window.removeEventListener("keydown", handler)
-  }, [undo, redo])
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [undo, redo]);
 
   useEffect(() => {
     // project -> graph
-    const ns: DialogNode[] = proj.dialogs.flatMap(d =>
-      d.nodes.map((n, idx): DialogNode => ({
-        id: n.id,
-        data: { label: n.text?.slice(0, 40) || n.id },
-        position: { x: (idx % 6) * 180, y: Math.floor(idx / 6) * 120 }
-      }))
-    )
-    const es: DialogEdge[] = proj.dialogs.flatMap(d =>
-      d.nodes.flatMap(n =>
-        (n.choices || []).map((c): DialogEdge => ({
-          id: `${n.id}->${c.next}`,
-          source: n.id,
-          target: c.next || n.id
-        }))
-      )
-    )
-    setNodes(ns); setEdges(es)
-  }, [proj])
+    const ns: DialogNode[] = proj.dialogs.flatMap((d) =>
+      d.nodes.map(
+        (n, idx): DialogNode => ({
+          id: n.id,
+          data: { label: n.text?.slice(0, 40) || n.id },
+          position: { x: (idx % 6) * 180, y: Math.floor(idx / 6) * 120 },
+        }),
+      ),
+    );
+    const es: DialogEdge[] = proj.dialogs.flatMap((d) =>
+      d.nodes.flatMap((n) =>
+        (n.choices || []).map(
+          (c): DialogEdge => ({
+            id: `${n.id}->${c.next}`,
+            source: n.id,
+            target: c.next || n.id,
+          }),
+        ),
+      ),
+    );
+    setNodes(ns);
+    setEdges(es);
+  }, [proj]);
 
   function addNode() {
-    const id = "n_" + Math.random().toString(36).slice(2,8)
-    setProj(prev => {
-      const d0: DialogProject["dialogs"][number] = prev.dialogs[0] || { id: "dlg_1", nodes: [] }
+    const id = "n_" + Math.random().toString(36).slice(2, 8);
+    setProj((prev) => {
+      const d0: DialogProject["dialogs"][number] = prev.dialogs[0] || {
+        id: "dlg_1",
+        nodes: [],
+      };
       const next: DialogProject = {
         ...prev,
         dialogs: [
-          { ...d0, nodes: [...d0.nodes, { id, text: "Новая реплика", choices: [] }] },
-          ...prev.dialogs.slice(1)
-        ]
-      }
-      return next
-    })
-    setStatus("Добавлен узел-реплика")
+          {
+            ...d0,
+            nodes: [...d0.nodes, { id, text: "Новая реплика", choices: [] }],
+          },
+          ...prev.dialogs.slice(1),
+        ],
+      };
+      return next;
+    });
+    setStatus("Добавлен узел-реплика");
   }
 
   function onConnect(c: Connection) {
-    if (!c.source || !c.target) return
-    setProj(prev => {
-      const d0 = prev.dialogs[0]
-      if (!d0) return prev
-      const nodes = d0.nodes.map(n => n.id===c.source
-        ? { ...n, choices: [...(n.choices || []), { text: "→", next: c.target! }] }
-        : n
-      )
-      const next: DialogProject = { ...prev, dialogs: [{ ...d0, nodes }] }
-      return next
-    })
-    setStatus(`Связь: ${c.source} → ${c.target}`)
-    setEdges(eds => addEdge({ source: c.source!, target: c.target!, id: `${c.source}->${c.target}` }, eds))
-  }
-
-  function importJson() {
-    loadFileAsText(".json").then(text => {
-      if (!text) return
-      try {
-        const parsed = validateDialogProject(JSON.parse(text))
-        setProj(parsed); setStatus("Импортирован JSON диалога")
-      } catch (e:any) {
-        setStatus("Ошибка: " + e.message)
-      }
-    })
-  }
-
-  function exportJson() {
-    const out = JSON.stringify(proj, null, 2)
-    saveTextFile(out, "dialogs.json")
-    setStatus("Экспортирован dialogs.json")
+    if (!c.source || !c.target) return;
+    setProj((prev) => {
+      const d0 = prev.dialogs[0];
+      if (!d0) return prev;
+      const nodes = d0.nodes.map((n) =>
+        n.id === c.source
+          ? {
+              ...n,
+              choices: [...(n.choices || []), { text: "→", next: c.target! }],
+            }
+          : n,
+      );
+      const next: DialogProject = { ...prev, dialogs: [{ ...d0, nodes }] };
+      return next;
+    });
+    setStatus(`Связь: ${c.source} → ${c.target}`);
+    setEdges((eds) =>
+      addEdge(
+        {
+          source: c.source!,
+          target: c.target!,
+          id: `${c.source}->${c.target}`,
+        },
+        eds,
+      ),
+    );
   }
 
   return (
-    <div style={{ display:"grid", gridTemplateColumns: "240px 1fr", width:"100%", position:"relative" }}>
-      <div style={{ position:"absolute", bottom:8, left:8, display:"flex", gap:8 }}>
-        <button onClick={importJson}>Импорт JSON</button>
-        <button onClick={exportJson}>Экспорт JSON</button>
-      </div>
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "240px 1fr",
+        width: "100%",
+        position: "relative",
+      }}
+    >
       <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
-        <button onClick={addNode} style={{ marginBottom:8 }}>+ Узел</button>
-        <div style={{ marginTop: 12, fontSize:12, opacity:0.8 }}>{status}</div>
-        <p style={{ fontSize:12, opacity:0.8 }}>Подсказка: соединяйте узлы линиями для создания переходов.</p>
+        <button onClick={addNode} style={{ marginBottom: 8 }}>
+          + Узел
+        </button>
+        <div style={{ marginTop: 12, fontSize: 12, opacity: 0.8 }}>
+          {status}
+        </div>
+        <p style={{ fontSize: 12, opacity: 0.8 }}>
+          Подсказка: соединяйте узлы линиями для создания переходов.
+        </p>
       </aside>
-      <section style={{ position:"relative", height: "calc(100vh - 100px)" }}>
-        <ReactFlow nodes={nodes} edges={edges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} fitView>
+      <section style={{ position: "relative", height: "calc(100vh - 100px)" }}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          fitView
+        >
           <MiniMap />
           <Controls />
           <Background />
         </ReactFlow>
       </section>
     </div>
-  )
+  );
 }
 
-export default function DialogEditor(){
+export default function DialogEditor() {
   return (
     <ReactFlowProvider>
       <Graph />
     </ReactFlowProvider>
-  )
+  );
 }

--- a/src/components/ScenesEditor.test.tsx
+++ b/src/components/ScenesEditor.test.tsx
@@ -1,19 +1,15 @@
-import { render, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock('@core/utils', async () => {
-  const actual = await vi.importActual<any>('@core/utils');
-  return {
-    ...actual,
-    loadFileAsText: vi.fn(),
-    saveTextFile: vi.fn(),
-  };
-});
+vi.mock("../services/api", () => ({
+  fetchScenes: vi.fn(),
+  saveScene: vi.fn(),
+}));
 
-import ScenesEditor from './ScenesEditor';
-import { loadFileAsText, saveTextFile } from '@core/utils';
-import { useSceneStore } from '../store';
-import { emptyProject } from '@core/sceneSchema';
+import ScenesEditor from "./ScenesEditor";
+import { fetchScenes, saveScene } from "../services/api";
+import { useSceneStore } from "../store";
+import { emptyProject } from "@core/sceneSchema";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ЧАСТЬ 1: тест клонирования хотспота (structuredClone)
@@ -21,26 +17,26 @@ import { emptyProject } from '@core/sceneSchema';
 // ─────────────────────────────────────────────────────────────────────────────
 type THotspot = {
   id: string;
-  shape: 'rect' | 'polygon' | 'circle';
+  shape: "rect" | "polygon" | "circle";
   rect?: { x: number; y: number; w: number; h: number };
   tooltip?: string | undefined;
   // допускаем любые доп. поля
   [key: string]: any;
 };
 
-describe('ScenesEditor hotspot cloning', () => {
-  it('preserves undefined and Date properties', () => {
+describe("ScenesEditor hotspot cloning", () => {
+  it("preserves undefined and Date properties", () => {
     const original: THotspot & { created: Date } = {
-      id: 'hs1',
-      shape: 'rect',
+      id: "hs1",
+      shape: "rect",
       hidden: false,
       rect: { x: 0.1, y: 0.2, w: 0.3, h: 0.4 },
       tooltip: undefined,
-      created: new Date('2024-06-01T00:00:00Z'),
+      created: new Date("2024-06-01T00:00:00Z"),
     };
     const copy = structuredClone(original);
     expect(copy).not.toBe(original);
-    expect('tooltip' in copy).toBe(true);
+    expect("tooltip" in copy).toBe(true);
     expect(copy.tooltip).toBeUndefined();
     expect(copy.created).toBeInstanceOf(Date);
     expect(copy.created.getTime()).toBe(original.created.getTime());
@@ -48,17 +44,20 @@ describe('ScenesEditor hotspot cloning', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// ЧАСТЬ 2: тесты компонента ScenesEditor (импорт/экспорт и добавление хотспота)
+// ЧАСТЬ 2: тесты компонента ScenesEditor (загрузка, сохранение, добавление хотспота)
 // ─────────────────────────────────────────────────────────────────────────────
 
 const sampleProject = {
-  version: '1.0',
-  project: { reference_resolution: { width: 100, height: 100 }, coords_mode: 'relative' },
-  scenes: [{ id: 's1', hotspots: [] }],
+  version: "1.0",
+  project: {
+    reference_resolution: { width: 100, height: 100 },
+    coords_mode: "relative",
+  },
+  scenes: [{ id: "s1", hotspots: [] }],
 };
 
 function mockCanvas() {
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
     configurable: true,
     value: () => ({
       save: vi.fn(),
@@ -75,57 +74,54 @@ function mockCanvas() {
       strokeRect: vi.fn(),
       translate: vi.fn(),
       clearRect: vi.fn(),
-      strokeStyle: '',
-      fillStyle: '',
+      strokeStyle: "",
+      fillStyle: "",
       globalAlpha: 1,
       lineWidth: 1,
     }),
   });
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getBoundingClientRect', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getBoundingClientRect", {
     configurable: true,
-    value: () => ({ left: 0, top: 0, width: 100, height: 100, right: 100, bottom: 100, x: 0, y: 0 }),
+    value: () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+    }),
   });
 }
 
-describe('ScenesEditor', () => {
+describe("ScenesEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCanvas();
-
-    localStorage.clear();
-
     useSceneStore.getState().resetProj(emptyProject());
 
-    ;(globalThis as any).fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        text: () => Promise.resolve(JSON.stringify(sampleProject)),
-      } as any),
-    ) as any;
+    (fetchScenes as any).mockResolvedValue(sampleProject);
+    (saveScene as any).mockResolvedValue(undefined);
   });
 
-  it('imports and exports JSON', async () => {
-    (loadFileAsText as any).mockResolvedValue(JSON.stringify(sampleProject));
+  it("adds rect hotspot via panel (matches current UI)", async () => {
     const { getByText } = render(<ScenesEditor />);
-    await waitFor(() => getByText('Загружен samples/scenes.json'));
-    fireEvent.click(getByText('Импорт JSON'));
-    await waitFor(() => expect(loadFileAsText).toHaveBeenCalled());
-    await waitFor(() => getByText('Импорт JSON выполнен'));
-    fireEvent.click(getByText('Экспорт JSON'));
-    await waitFor(() => expect(saveTextFile).toHaveBeenCalled());
-    await waitFor(() => getByText('Экспортировано scenes.json'));
+    await waitFor(() => expect(fetchScenes).toHaveBeenCalled());
+    fireEvent.click(getByText("+ Rect"));
+    await waitFor(() => getByText("Добавлен прямоугольный хотспот"));
   });
 
-  it('adds rect hotspot via panel (matches current UI)', async () => {
+  it("saves project via API", async () => {
     const { getByText } = render(<ScenesEditor />);
-    await waitFor(() => getByText('Загружен samples/scenes.json'));
-    fireEvent.click(getByText('+ Rect'));
-    await waitFor(() => getByText('Добавлен прямоугольный хотспот'));
+    await waitFor(() => expect(fetchScenes).toHaveBeenCalled());
+    fireEvent.click(getByText("Сохранить"));
+    await waitFor(() => expect(saveScene).toHaveBeenCalled());
+    await waitFor(() => getByText("Сцены сохранены"));
   });
 
-  it.skip('updates hotspot coordinates on drag (not implemented in MVP)', async () => {
+  it.skip("updates hotspot coordinates on drag (not implemented in MVP)", async () => {
     // Отключено: текущий MVP не поддерживает drag/resize хотспотов и поля X/Y.
     // Когда добавим drag’n’drop — вернём тест.
   });
 });
-

--- a/src/components/ScenesEditor.tsx
+++ b/src/components/ScenesEditor.tsx
@@ -1,32 +1,50 @@
-import React, { useEffect, useMemo, useRef, useState } from "react"
-import { Layer, type Point, type Hotspot } from "@core/sceneSchema"
-import { useSceneStore } from "../store"
-import { round3, convertProjectCoordsMode } from "@core/utils"
-import { importSceneProjectFromFile, exportSceneProjectToFile, saveProjectToStorage, loadProjectFromStorage, parseSceneProject } from "@core/scenePersistence"
-import HotspotPanel from "./HotspotPanel"
-import { drawHotspot, hitTestHotspot, translateHotspot, moveVertexTo, setCircleRadius, insertVertex } from "./HotspotShape"
-import LayerPanel from "./LayerPanel"
-import LayerInspector from "./LayerInspector"
-import CanvasView from "./CanvasView"
-import HotspotInspector from "./HotspotInspector"
-import { HotspotContext } from "./HotspotContext"
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Layer, type Point, type Hotspot } from "@core/sceneSchema";
+import { useSceneStore } from "../store";
+import { round3, convertProjectCoordsMode } from "@core/utils";
+import { fetchScenes, saveScene } from "../services/api";
+import HotspotPanel from "./HotspotPanel";
+import {
+  drawHotspot,
+  hitTestHotspot,
+  translateHotspot,
+  moveVertexTo,
+  setCircleRadius,
+  insertVertex,
+} from "./HotspotShape";
+import LayerPanel from "./LayerPanel";
+import LayerInspector from "./LayerInspector";
+import CanvasView from "./CanvasView";
+import HotspotInspector from "./HotspotInspector";
+import { HotspotContext } from "./HotspotContext";
 
 export default function ScenesEditor() {
-  const proj = useSceneStore(s => s.proj)
-  const setProj = useSceneStore(s => s.setProj)
-  const resetProj = useSceneStore(s => s.resetProj)
-  const undo = useSceneStore(s => s.undo)
-  const redo = useSceneStore(s => s.redo)
-  const [status, setStatus] = useState<string>("")
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const [activeSceneId, setActiveSceneId] = useState<string | undefined>(undefined)
-  const [drag, setDrag] = useState<{ hsIndex: number; mode: "move"|"vertex"|"radius"; vertexIndex?: number; prevX: number; prevY: number } | null>(null)
-  const [selectedHs, setSelectedHs] = useState<number | null>(null)
-  const [manualRes, setManualRes] = useState(false)
-  const [preview, setPreview] = useState(false)
-  const [useWebGL, setUseWebGL] = useState(false)
-  const [selectedLayerId, setSelectedLayerId] = useState<string | null>(null)
-  const [canvasSize, setCanvasSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+  const proj = useSceneStore((s) => s.proj);
+  const setProj = useSceneStore((s) => s.setProj);
+  const resetProj = useSceneStore((s) => s.resetProj);
+  const undo = useSceneStore((s) => s.undo);
+  const redo = useSceneStore((s) => s.redo);
+  const [status, setStatus] = useState<string>("");
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [activeSceneId, setActiveSceneId] = useState<string | undefined>(
+    undefined,
+  );
+  const [drag, setDrag] = useState<{
+    hsIndex: number;
+    mode: "move" | "vertex" | "radius";
+    vertexIndex?: number;
+    prevX: number;
+    prevY: number;
+  } | null>(null);
+  const [selectedHs, setSelectedHs] = useState<number | null>(null);
+  const [manualRes, setManualRes] = useState(false);
+  const [preview, setPreview] = useState(false);
+  const [useWebGL, setUseWebGL] = useState(false);
+  const [selectedLayerId, setSelectedLayerId] = useState<string | null>(null);
+  const [canvasSize, setCanvasSize] = useState<{
+    width: number;
+    height: number;
+  }>({ width: 0, height: 0 });
 
   const resolutions = [
     { label: "640x480", width: 640, height: 480 },
@@ -34,194 +52,240 @@ export default function ScenesEditor() {
     { label: "1024x768", width: 1024, height: 768 },
     { label: "1280x720", width: 1280, height: 720 },
     { label: "1920x1080", width: 1920, height: 1080 },
-  ]
+  ];
 
-  // load from localStorage or sample on first run
+  // load scenes from API on first run
   useEffect(() => {
-    const stored = loadProjectFromStorage()
-    if (stored) {
-      resetProj(stored)
-      setActiveSceneId(stored.scenes[0]?.id)
-      setStatus("Загружен проект из localStorage")
-      return
-    }
-    fetch("/samples/scenes.json")
-      .then(r => r.ok ? r.text() : Promise.reject("no sample"))
-      .then(text => {
-        try {
-          const json = JSON.parse(text)
-          const parsed = parseSceneProject(json)
-          resetProj(parsed)
-          setActiveSceneId(parsed.scenes[0]?.id)
-          setStatus("Загружен samples/scenes.json")
-        } catch (e:any) {
-          setStatus("Не удалось загрузить sample: " + e.message)
-        }
+    fetchScenes()
+      .then((parsed) => {
+        resetProj(parsed);
+        setActiveSceneId(parsed.scenes[0]?.id);
+        setStatus("Сцены загружены");
       })
-      .catch(() => {})
-  }, [])
+      .catch((e: any) => {
+        setStatus("Ошибка загрузки: " + e.message);
+      });
+  }, [resetProj]);
 
   useEffect(() => {
-    setSelectedHs(null)
-    setSelectedLayerId(null)
-  }, [activeSceneId])
+    setSelectedHs(null);
+    setSelectedLayerId(null);
+  }, [activeSceneId]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "z" && !e.shiftKey) {
-        e.preventDefault()
-        undo()
-      } else if ((e.ctrlKey || e.metaKey) && (e.key.toLowerCase() === "y" || (e.shiftKey && e.key.toLowerCase() === "z"))) {
-        e.preventDefault()
-        redo()
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        e.key.toLowerCase() === "z" &&
+        !e.shiftKey
+      ) {
+        e.preventDefault();
+        undo();
+      } else if (
+        (e.ctrlKey || e.metaKey) &&
+        (e.key.toLowerCase() === "y" ||
+          (e.shiftKey && e.key.toLowerCase() === "z"))
+      ) {
+        e.preventDefault();
+        redo();
       }
-    }
-    window.addEventListener("keydown", handler)
-    return () => window.removeEventListener("keydown", handler)
-  }, [undo, redo])
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [undo, redo]);
 
   useEffect(() => {
-    const canvas = canvasRef.current
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!canvas || !scene) return
-    const rect = canvas.getBoundingClientRect()
-    canvas.width = rect.width
-    canvas.height = rect.height
-    setCanvasSize({ width: canvas.width, height: canvas.height })
-    const ctx = canvas.getContext("2d")!
-    const W = canvas.width, H = canvas.height
-    ctx.clearRect(0,0,W,H)
+    const canvas = canvasRef.current;
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!canvas || !scene) return;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width;
+    canvas.height = rect.height;
+    setCanvasSize({ width: canvas.width, height: canvas.height });
+    const ctx = canvas.getContext("2d")!;
+    const W = canvas.width,
+      H = canvas.height;
+    ctx.clearRect(0, 0, W, H);
     // grid
-    ctx.globalAlpha = 1
-    ctx.strokeStyle = "#e9e9e9"
-    for (let x=0; x<W; x+=40) { ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,H); ctx.stroke() }
-    for (let y=0; y<H; y+=40) { ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(W,y); ctx.stroke() }
+    ctx.globalAlpha = 1;
+    ctx.strokeStyle = "#e9e9e9";
+    for (let x = 0; x < W; x += 40) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, H);
+      ctx.stroke();
+    }
+    for (let y = 0; y < H; y += 40) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(W, y);
+      ctx.stroke();
+    }
 
     // border of scene
-    ctx.strokeStyle = "#bbb"
-    ctx.lineWidth = 1
-    ctx.strokeRect(0.5,0.5,W-1,H-1)
+    ctx.strokeStyle = "#bbb";
+    ctx.lineWidth = 1;
+    ctx.strokeRect(0.5, 0.5, W - 1, H - 1);
 
     // draw hotspots
     for (const hs of scene.hotspots ?? []) {
-      if (!hs.hidden) drawHotspot(ctx, proj, hs, W, H)
+      if (!hs.hidden) drawHotspot(ctx, proj, hs, W, H);
     }
-  }, [proj, activeSceneId])
+  }, [proj, activeSceneId]);
 
-  function onImportClicked() {
-    importSceneProjectFromFile().then(parsed => {
-      if (!parsed) return
-      try {
-        setProj(parsed)
-        setActiveSceneId(parsed.scenes[0]?.id)
-        setStatus("Импорт JSON выполнен")
-      } catch (e:any) {
-        setStatus("Ошибка валидации: " + e.message)
-      }
-    }).catch((e:any) => {
-      setStatus("Ошибка валидации: " + e.message)
-    })
-  }
-
-  function onExportClicked() {
-    exportSceneProjectToFile(proj)
-    setStatus("Экспортировано scenes.json")
-  }
-
-  function onSaveClicked() {
-    saveProjectToStorage(proj)
-    setStatus("Сохранено в localStorage")
-  }
-
-  function onLoadClicked() {
-    const loaded = loadProjectFromStorage()
-    if (loaded) {
-      setProj(loaded)
-      setActiveSceneId(loaded.scenes[0]?.id)
-      setStatus("Загружено из localStorage")
-    } else {
-      setStatus("Нет сохранённого проекта")
+  async function onSaveClicked() {
+    try {
+      await saveScene(proj);
+      setStatus("Сцены сохранены");
+    } catch (e: any) {
+      setStatus("Ошибка сохранения: " + e.message);
     }
   }
 
   function addImageLayer() {
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!scene) return
-    const id = "layer_" + Math.random().toString(36).slice(2,8)
-    const layers = [...scene.layers, { id, type: "image" as const, image: "", alpha: 1, zorder: scene.layers.length }]
-    const next = { ...proj, scenes: proj.scenes.map(s => s.id === scene.id ? { ...s, layers } : s) }
-    setProj(next)
-    setSelectedLayerId(id)
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!scene) return;
+    const id = "layer_" + Math.random().toString(36).slice(2, 8);
+    const layers = [
+      ...scene.layers,
+      {
+        id,
+        type: "image" as const,
+        image: "",
+        alpha: 1,
+        zorder: scene.layers.length,
+      },
+    ];
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s) =>
+        s.id === scene.id ? { ...s, layers } : s,
+      ),
+    };
+    setProj(next);
+    setSelectedLayerId(id);
   }
 
   function addColorLayer() {
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!scene) return
-    const id = "layer_" + Math.random().toString(36).slice(2,8)
-    const layers = [...scene.layers, { id, type: "color" as const, color: "#000000", alpha: 1, zorder: scene.layers.length }]
-    const next = { ...proj, scenes: proj.scenes.map(s => s.id === scene.id ? { ...s, layers } : s) }
-    setProj(next)
-    setSelectedLayerId(id)
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!scene) return;
+    const id = "layer_" + Math.random().toString(36).slice(2, 8);
+    const layers = [
+      ...scene.layers,
+      {
+        id,
+        type: "color" as const,
+        color: "#000000",
+        alpha: 1,
+        zorder: scene.layers.length,
+      },
+    ];
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s) =>
+        s.id === scene.id ? { ...s, layers } : s,
+      ),
+    };
+    setProj(next);
+    setSelectedLayerId(id);
   }
 
   function updateLayer(id: string, layer: Layer) {
-    const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
-    if (sceneIndex < 0) return
-    const scene = proj.scenes[sceneIndex]
-    const layers = scene.layers.map(l => l.id === id ? layer : l).map((l,i) => ({ ...l, zorder: i }))
-    const next = { ...proj, scenes: proj.scenes.map((s,i)=> i===sceneIndex? { ...s, layers }: s) }
-    setProj(next)
+    const sceneIndex = proj.scenes.findIndex((s) => s.id === activeSceneId);
+    if (sceneIndex < 0) return;
+    const scene = proj.scenes[sceneIndex];
+    const layers = scene.layers
+      .map((l) => (l.id === id ? layer : l))
+      .map((l, i) => ({ ...l, zorder: i }));
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s, i) =>
+        i === sceneIndex ? { ...s, layers } : s,
+      ),
+    };
+    setProj(next);
   }
 
   function deleteLayer(id: string) {
-    const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
-    if (sceneIndex < 0) return
-    const scene = proj.scenes[sceneIndex]
-    const layers = scene.layers.filter(l => l.id !== id).map((l,i)=> ({ ...l, zorder: i }))
-    const next = { ...proj, scenes: proj.scenes.map((s,i)=> i===sceneIndex? { ...s, layers }: s) }
-    setProj(next)
-    if (selectedLayerId === id) setSelectedLayerId(null)
+    const sceneIndex = proj.scenes.findIndex((s) => s.id === activeSceneId);
+    if (sceneIndex < 0) return;
+    const scene = proj.scenes[sceneIndex];
+    const layers = scene.layers
+      .filter((l) => l.id !== id)
+      .map((l, i) => ({ ...l, zorder: i }));
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s, i) =>
+        i === sceneIndex ? { ...s, layers } : s,
+      ),
+    };
+    setProj(next);
+    if (selectedLayerId === id) setSelectedLayerId(null);
   }
 
   function copyLayer(id: string) {
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!scene) return
-    const layer = scene.layers.find(l => l.id === id)
-    if (!layer) return
-    const newId = id + "_copy"
-    const copy: Layer = { ...layer, id: newId }
-    const layers = [...scene.layers, { ...copy, zorder: scene.layers.length }]
-    const next = { ...proj, scenes: proj.scenes.map(s => s.id === scene.id ? { ...s, layers } : s) }
-    setProj(next)
-    setSelectedLayerId(newId)
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!scene) return;
+    const layer = scene.layers.find((l) => l.id === id);
+    if (!layer) return;
+    const newId = id + "_copy";
+    const copy: Layer = { ...layer, id: newId };
+    const layers = [...scene.layers, { ...copy, zorder: scene.layers.length }];
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s) =>
+        s.id === scene.id ? { ...s, layers } : s,
+      ),
+    };
+    setProj(next);
+    setSelectedLayerId(newId);
   }
 
   function addDroppedImage(src: string) {
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!scene) return
-    const id = "layer_" + Math.random().toString(36).slice(2,8)
-    const layers = [...scene.layers, { id, type: "image" as const, image: src, alpha: 1, zorder: scene.layers.length }]
-    const next = { ...proj, scenes: proj.scenes.map(s => s.id === scene.id ? { ...s, layers } : s) }
-    setProj(next)
-    setSelectedLayerId(id)
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!scene) return;
+    const id = "layer_" + Math.random().toString(36).slice(2, 8);
+    const layers = [
+      ...scene.layers,
+      {
+        id,
+        type: "image" as const,
+        image: src,
+        alpha: 1,
+        zorder: scene.layers.length,
+      },
+    ];
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s) =>
+        s.id === scene.id ? { ...s, layers } : s,
+      ),
+    };
+    setProj(next);
+    setSelectedLayerId(id);
   }
 
   function reorderLayers(from: number, to: number) {
-    const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
-    if (sceneIndex < 0) return
-    const scene = proj.scenes[sceneIndex]
-    const layers = [...scene.layers]
-    const [item] = layers.splice(from, 1)
-    layers.splice(to, 0, item)
-    const relabeled = layers.map((l,i)=> ({ ...l, zorder: i }))
-    const next = { ...proj, scenes: proj.scenes.map((s,i)=> i===sceneIndex? { ...s, layers: relabeled }: s) }
-    setProj(next)
+    const sceneIndex = proj.scenes.findIndex((s) => s.id === activeSceneId);
+    if (sceneIndex < 0) return;
+    const scene = proj.scenes[sceneIndex];
+    const layers = [...scene.layers];
+    const [item] = layers.splice(from, 1);
+    layers.splice(to, 0, item);
+    const relabeled = layers.map((l, i) => ({ ...l, zorder: i }));
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s, i) =>
+        i === sceneIndex ? { ...s, layers: relabeled } : s,
+      ),
+    };
+    setProj(next);
   }
 
   function addRectHotspot() {
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!scene) return
-    const id = "hs_" + Math.random().toString(36).slice(2,8)
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!scene) return;
+    const id = "hs_" + Math.random().toString(36).slice(2, 8);
     const hs: Hotspot = {
       id,
       shape: "rect",
@@ -229,24 +293,26 @@ export default function ScenesEditor() {
       tooltip: "Новый хотспот",
       action: { type: "go_scene", scene_id: scene.id },
       hidden: false,
-    }
+    };
     const next = {
       ...proj,
-      scenes: proj.scenes.map(s =>
-        s.id === scene.id
-          ? { ...s, hotspots: [...(s.hotspots ?? []), hs] }
-          : s
+      scenes: proj.scenes.map((s) =>
+        s.id === scene.id ? { ...s, hotspots: [...(s.hotspots ?? []), hs] } : s,
       ),
-    }
-    setProj(next)
-    setStatus("Добавлен прямоугольный хотспот")
+    };
+    setProj(next);
+    setStatus("Добавлен прямоугольный хотспот");
   }
 
   function addPolygonHotspot() {
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!scene) return
-    const id = "hs_" + Math.random().toString(36).slice(2,8)
-    const points: Point[] = [[0.1,0.1],[0.2,0.1],[0.15,0.2]]
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!scene) return;
+    const id = "hs_" + Math.random().toString(36).slice(2, 8);
+    const points: Point[] = [
+      [0.1, 0.1],
+      [0.2, 0.1],
+      [0.15, 0.2],
+    ];
     const hs: Hotspot = {
       id,
       shape: "polygon",
@@ -254,24 +320,22 @@ export default function ScenesEditor() {
       tooltip: "Новый полигон",
       action: { type: "go_scene", scene_id: scene.id },
       hidden: false,
-    }
+    };
     const next = {
       ...proj,
-      scenes: proj.scenes.map(s =>
-        s.id === scene.id
-          ? { ...s, hotspots: [...(s.hotspots ?? []), hs] }
-          : s
+      scenes: proj.scenes.map((s) =>
+        s.id === scene.id ? { ...s, hotspots: [...(s.hotspots ?? []), hs] } : s,
       ),
-    }
-    setProj(next)
-    setStatus("Добавлен полигональный хотспот")
+    };
+    setProj(next);
+    setStatus("Добавлен полигональный хотспот");
   }
 
   function addCircleHotspot() {
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!scene) return
-    const id = "hs_" + Math.random().toString(36).slice(2,8)
-    const circle = { cx:0.3, cy:0.3, r:0.1 }
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!scene) return;
+    const id = "hs_" + Math.random().toString(36).slice(2, 8);
+    const circle = { cx: 0.3, cy: 0.3, r: 0.1 };
     const hs: Hotspot = {
       id,
       shape: "circle",
@@ -279,217 +343,346 @@ export default function ScenesEditor() {
       tooltip: "Новый круг",
       action: { type: "go_scene", scene_id: scene.id },
       hidden: false,
-    }
+    };
     const next = {
       ...proj,
-      scenes: proj.scenes.map(s =>
-        s.id === scene.id
-          ? { ...s, hotspots: [...(s.hotspots ?? []), hs] }
-          : s
+      scenes: proj.scenes.map((s) =>
+        s.id === scene.id ? { ...s, hotspots: [...(s.hotspots ?? []), hs] } : s,
       ),
-    }
-    setProj(next)
-    setStatus("Добавлен круглый хотспот")
+    };
+    setProj(next);
+    setStatus("Добавлен круглый хотспот");
   }
 
-  const sceneList = useMemo(() => proj.scenes.map(s => (
-    <li key={s.id}>
-      <button onClick={() => setActiveSceneId(s.id)} style={{ fontWeight: activeSceneId===s.id?600:400 }}>
-        {s.name || s.id}
-      </button>
-    </li>
-  )), [proj, activeSceneId])
+  const sceneList = useMemo(
+    () =>
+      proj.scenes.map((s) => (
+        <li key={s.id}>
+          <button
+            onClick={() => setActiveSceneId(s.id)}
+            style={{ fontWeight: activeSceneId === s.id ? 600 : 400 }}
+          >
+            {s.name || s.id}
+          </button>
+        </li>
+      )),
+    [proj, activeSceneId],
+  );
 
   function updateHotspot(index: number, hs: Hotspot) {
-    const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
-    if (sceneIndex < 0) return
-    const scene = proj.scenes[sceneIndex]
-    const hotspots = scene.hotspots!.map((h,i)=> i===index?hs:h)
-    const next = { ...proj, scenes: proj.scenes.map((s,i)=> i===sceneIndex?{...s, hotspots}:s) }
-    setProj(next)
+    const sceneIndex = proj.scenes.findIndex((s) => s.id === activeSceneId);
+    if (sceneIndex < 0) return;
+    const scene = proj.scenes[sceneIndex];
+    const hotspots = scene.hotspots!.map((h, i) => (i === index ? hs : h));
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s, i) =>
+        i === sceneIndex ? { ...s, hotspots } : s,
+      ),
+    };
+    setProj(next);
   }
 
   function toggleHotspotVisibility(index: number) {
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!scene) return
-    const hs = scene.hotspots![index]
-    const hsCopy = { ...hs, hidden: !hs.hidden }
-    updateHotspot(index, hsCopy)
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!scene) return;
+    const hs = scene.hotspots![index];
+    const hsCopy = { ...hs, hidden: !hs.hidden };
+    updateHotspot(index, hsCopy);
   }
 
   function handleMouseDown(e: React.MouseEvent<HTMLCanvasElement>) {
-    const canvas = canvasRef.current
-    const scene = proj.scenes.find(s => s.id === activeSceneId)
-    if (!canvas || !scene) return
-    const rect = canvas.getBoundingClientRect()
-    const scaleX = canvas.width / rect.width
-    const scaleY = canvas.height / rect.height
-    const x = (e.clientX - rect.left) * scaleX
-    const y = (e.clientY - rect.top) * scaleY
-    const W = canvas.width, H = canvas.height
-    for (let i=(scene.hotspots?.length||0)-1; i>=0; i--) {
-      const hs = scene.hotspots![i]
-      if (hs.hidden) continue
-      const hit = hitTestHotspot(proj, hs, W, H, x, y)
+    const canvas = canvasRef.current;
+    const scene = proj.scenes.find((s) => s.id === activeSceneId);
+    if (!canvas || !scene) return;
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
+    const W = canvas.width,
+      H = canvas.height;
+    for (let i = (scene.hotspots?.length || 0) - 1; i >= 0; i--) {
+      const hs = scene.hotspots![i];
+      if (hs.hidden) continue;
+      const hit = hitTestHotspot(proj, hs, W, H, x, y);
       if (hit) {
-        setSelectedHs(i)
+        setSelectedHs(i);
         if (hit.kind === "add") {
-          const hsCopy: Hotspot = structuredClone(hs)
-          insertVertex(hsCopy, proj, hit.index, x, y, W, H)
-          const hotspots = scene.hotspots!.map((h,j)=> j===i?hsCopy:h)
-          const next = { ...proj, scenes: proj.scenes.map(s => s.id===scene.id? {...s, hotspots}: s) }
-          setProj(next)
-          setDrag({ hsIndex:i, mode:"vertex", vertexIndex: hit.index+1, prevX:x, prevY:y })
+          const hsCopy: Hotspot = structuredClone(hs);
+          insertVertex(hsCopy, proj, hit.index, x, y, W, H);
+          const hotspots = scene.hotspots!.map((h, j) =>
+            j === i ? hsCopy : h,
+          );
+          const next = {
+            ...proj,
+            scenes: proj.scenes.map((s) =>
+              s.id === scene.id ? { ...s, hotspots } : s,
+            ),
+          };
+          setProj(next);
+          setDrag({
+            hsIndex: i,
+            mode: "vertex",
+            vertexIndex: hit.index + 1,
+            prevX: x,
+            prevY: y,
+          });
         } else if (hit.kind === "vertex") {
-          setDrag({ hsIndex:i, mode:"vertex", vertexIndex: hit.index, prevX:x, prevY:y })
+          setDrag({
+            hsIndex: i,
+            mode: "vertex",
+            vertexIndex: hit.index,
+            prevX: x,
+            prevY: y,
+          });
         } else if (hit.kind === "radius") {
-          setDrag({ hsIndex:i, mode:"radius", prevX:x, prevY:y })
+          setDrag({ hsIndex: i, mode: "radius", prevX: x, prevY: y });
         } else if (hit.kind === "move") {
-          setDrag({ hsIndex:i, mode:"move", prevX:x, prevY:y })
+          setDrag({ hsIndex: i, mode: "move", prevX: x, prevY: y });
         }
-        break
+        break;
       }
     }
   }
 
   function handleMouseMove(e: React.MouseEvent<HTMLCanvasElement>) {
-    if (!drag) return
-    const canvas = canvasRef.current
-    const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
-    if (!canvas || sceneIndex < 0) return
-    const rect = canvas.getBoundingClientRect()
-    const scaleX = canvas.width / rect.width
-    const scaleY = canvas.height / rect.height
-    const x = (e.clientX - rect.left) * scaleX
-    const y = (e.clientY - rect.top) * scaleY
-    const W = canvas.width, H = canvas.height
-    const scene = proj.scenes[sceneIndex]
-    const hs = scene.hotspots![drag.hsIndex]
-    const hsCopy: Hotspot = structuredClone(hs)
+    if (!drag) return;
+    const canvas = canvasRef.current;
+    const sceneIndex = proj.scenes.findIndex((s) => s.id === activeSceneId);
+    if (!canvas || sceneIndex < 0) return;
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
+    const W = canvas.width,
+      H = canvas.height;
+    const scene = proj.scenes[sceneIndex];
+    const hs = scene.hotspots![drag.hsIndex];
+    const hsCopy: Hotspot = structuredClone(hs);
     if (drag.mode === "move") {
-      translateHotspot(hsCopy, proj, x - drag.prevX, y - drag.prevY, W, H)
+      translateHotspot(hsCopy, proj, x - drag.prevX, y - drag.prevY, W, H);
     } else if (drag.mode === "vertex" && drag.vertexIndex !== undefined) {
-      moveVertexTo(hsCopy, proj, drag.vertexIndex, x, y, W, H)
+      moveVertexTo(hsCopy, proj, drag.vertexIndex, x, y, W, H);
     } else if (drag.mode === "radius") {
-      setCircleRadius(hsCopy, proj, x, y, W, H)
+      setCircleRadius(hsCopy, proj, x, y, W, H);
     }
-    const hotspots = scene.hotspots!.map((h,j)=> j===drag.hsIndex?hsCopy:h)
-    const next = { ...proj, scenes: proj.scenes.map((s,si)=> si===sceneIndex? {...s, hotspots}: s) }
-    setProj(next)
-    setDrag({ ...drag, prevX:x, prevY:y })
+    const hotspots = scene.hotspots!.map((h, j) =>
+      j === drag.hsIndex ? hsCopy : h,
+    );
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s, si) =>
+        si === sceneIndex ? { ...s, hotspots } : s,
+      ),
+    };
+    setProj(next);
+    setDrag({ ...drag, prevX: x, prevY: y });
   }
 
   function handleMouseUp() {
-    setDrag(null)
+    setDrag(null);
   }
 
-  const activeScene = proj.scenes.find(s => s.id === activeSceneId)
+  const activeScene = proj.scenes.find((s) => s.id === activeSceneId);
 
-  const activeHotspot = selectedHs !== null && activeScene ? activeScene.hotspots![selectedHs] : null
-  const activeLayer = activeScene?.layers.find(l => l.id === selectedLayerId) || null
+  const activeHotspot =
+    selectedHs !== null && activeScene
+      ? activeScene.hotspots![selectedHs]
+      : null;
+  const activeLayer =
+    activeScene?.layers.find((l) => l.id === selectedLayerId) || null;
 
   function handleSceneNameChange(name: string) {
-    const sceneIndex = proj.scenes.findIndex(s => s.id === activeSceneId)
-    if (sceneIndex < 0) return
-    const next = { ...proj, scenes: proj.scenes.map((s,i)=> i===sceneIndex? { ...s, name }: s) }
-    setProj(next)
+    const sceneIndex = proj.scenes.findIndex((s) => s.id === activeSceneId);
+    if (sceneIndex < 0) return;
+    const next = {
+      ...proj,
+      scenes: proj.scenes.map((s, i) =>
+        i === sceneIndex ? { ...s, name } : s,
+      ),
+    };
+    setProj(next);
   }
 
   function openPreview() {
-    document.documentElement.requestFullscreen?.()
-    setPreview(true)
+    document.documentElement.requestFullscreen?.();
+    setPreview(true);
   }
 
   function closePreview() {
-    if (document.fullscreenElement) document.exitFullscreen()
-    setPreview(false)
+    if (document.fullscreenElement) document.exitFullscreen();
+    setPreview(false);
   }
 
   return (
-    <div style={{ display:"grid", gridTemplateColumns: "280px 1fr 300px", width:"100%", position:"relative" }}>
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "280px 1fr 300px",
+        width: "100%",
+        position: "relative",
+      }}
+    >
       <div
         style={{
           position: "absolute",
           bottom: 8,
           left: 8,
-          display: "grid",
-          gridTemplateColumns: "repeat(2, auto)",
-          gap: 8,
         }}
       >
         <button onClick={onSaveClicked}>Сохранить</button>
-        <button onClick={onLoadClicked}>Загрузить</button>
-        <button onClick={onImportClicked}>Импорт JSON</button>
-        <button onClick={onExportClicked}>Экспорт JSON</button>
       </div>
       <aside style={{ borderRight: "1px solid #eee", padding: 12 }}>
-        <div style={{ display:"flex", gap:8, flexWrap:"wrap", marginBottom: 8, alignItems:"center" }}>
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            flexWrap: "wrap",
+            marginBottom: 8,
+            alignItems: "center",
+          }}
+        >
           <button onClick={openPreview}>Превью</button>
-          <label style={{ display:"flex", alignItems:"center", gap:4 }}>
-            <input type="checkbox" checked={useWebGL} onChange={e=>setUseWebGL(e.target.checked)} />WebGL
+          <label style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <input
+              type="checkbox"
+              checked={useWebGL}
+              onChange={(e) => setUseWebGL(e.target.checked)}
+            />
+            WebGL
           </label>
         </div>
-        <div style={{ marginBottom:8 }}>
+        <div style={{ marginBottom: 8 }}>
           <strong>Экран</strong>
           {!manualRes ? (
-            <div style={{ display:"flex", gap:4 }}>
-              <select value={`${proj.project.reference_resolution.width}x${proj.project.reference_resolution.height}`} onChange={e=>{
-                const [w,h] = e.target.value.split('x').map(n=>parseInt(n))
-                const next = { ...proj, project: { ...proj.project, reference_resolution: { width:w, height:h } } }
-                setProj(next)
-              }}>
-                {resolutions.map(r=> (
-                  <option key={r.label} value={`${r.width}x${r.height}`}>{r.label}</option>
+            <div style={{ display: "flex", gap: 4 }}>
+              <select
+                value={`${proj.project.reference_resolution.width}x${proj.project.reference_resolution.height}`}
+                onChange={(e) => {
+                  const [w, h] = e.target.value
+                    .split("x")
+                    .map((n) => parseInt(n));
+                  const next = {
+                    ...proj,
+                    project: {
+                      ...proj.project,
+                      reference_resolution: { width: w, height: h },
+                    },
+                  };
+                  setProj(next);
+                }}
+              >
+                {resolutions.map((r) => (
+                  <option key={r.label} value={`${r.width}x${r.height}`}>
+                    {r.label}
+                  </option>
                 ))}
               </select>
-              <button onClick={()=>setManualRes(true)}>Manual</button>
+              <button onClick={() => setManualRes(true)}>Manual</button>
             </div>
           ) : (
-            <div style={{ display:"flex", gap:4 }}>
-              <input type="number" value={proj.project.reference_resolution.width} onChange={e=>{
-                const w = parseInt(e.target.value)||0
-                const next = { ...proj, project: { ...proj.project, reference_resolution: { ...proj.project.reference_resolution, width:w } } }
-                setProj(next)
-              }} />
-              <input type="number" value={proj.project.reference_resolution.height} onChange={e=>{
-                const h = parseInt(e.target.value)||0
-                const next = { ...proj, project: { ...proj.project, reference_resolution: { ...proj.project.reference_resolution, height:h } } }
-                setProj(next)
-              }} />
-              <button onClick={()=>setManualRes(false)}>Presets</button>
+            <div style={{ display: "flex", gap: 4 }}>
+              <input
+                type="number"
+                value={proj.project.reference_resolution.width}
+                onChange={(e) => {
+                  const w = parseInt(e.target.value) || 0;
+                  const next = {
+                    ...proj,
+                    project: {
+                      ...proj.project,
+                      reference_resolution: {
+                        ...proj.project.reference_resolution,
+                        width: w,
+                      },
+                    },
+                  };
+                  setProj(next);
+                }}
+              />
+              <input
+                type="number"
+                value={proj.project.reference_resolution.height}
+                onChange={(e) => {
+                  const h = parseInt(e.target.value) || 0;
+                  const next = {
+                    ...proj,
+                    project: {
+                      ...proj.project,
+                      reference_resolution: {
+                        ...proj.project.reference_resolution,
+                        height: h,
+                      },
+                    },
+                  };
+                  setProj(next);
+                }}
+              />
+              <button onClick={() => setManualRes(false)}>Presets</button>
             </div>
           )}
-          <label style={{ display:'block', marginTop:4 }}>Mode
-            <select value={proj.project.coords_mode} onChange={e=>{
-              const mode = e.target.value as 'relative'|'absolute'
-              const converted = convertProjectCoordsMode(proj, mode)
-              setProj(converted)
-            }}>
+          <label style={{ display: "block", marginTop: 4 }}>
+            Mode
+            <select
+              value={proj.project.coords_mode}
+              onChange={(e) => {
+                const mode = e.target.value as "relative" | "absolute";
+                const converted = convertProjectCoordsMode(proj, mode);
+                setProj(converted);
+              }}
+            >
               <option value="relative">relative</option>
               <option value="absolute">absolute</option>
             </select>
           </label>
         </div>
-        <HotspotPanel onAddRect={addRectHotspot} onAddPolygon={addPolygonHotspot} onAddCircle={addCircleHotspot} />
+        <HotspotPanel
+          onAddRect={addRectHotspot}
+          onAddPolygon={addPolygonHotspot}
+          onAddCircle={addCircleHotspot}
+        />
         <strong>Сцены</strong>
-        <ul style={{ listStyle:"none", padding:0 }}>{sceneList}</ul>
-        <div style={{ marginTop: 12, fontSize:12, opacity:0.8 }}>{status}</div>
+        <ul style={{ listStyle: "none", padding: 0 }}>{sceneList}</ul>
+        <div style={{ marginTop: 12, fontSize: 12, opacity: 0.8 }}>
+          {status}
+        </div>
       </aside>
-      <section style={{ display:"flex", alignItems:"center", justifyContent:"center" }}>
+      <section
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
         <div
-          style={{ width:"100%", height:"100%", maxWidth: "calc(100vw - 580px)", aspectRatio: "16/9", position:"relative", border:"1px solid #ddd", background:"#fff" }}
-          onDragOver={e => e.preventDefault()}
-          onDrop={e => {
-            e.preventDefault()
-            const files = e.dataTransfer.files
+          style={{
+            width: "100%",
+            height: "100%",
+            maxWidth: "calc(100vw - 580px)",
+            aspectRatio: "16/9",
+            position: "relative",
+            border: "1px solid #ddd",
+            background: "#fff",
+          }}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault();
+            const files = e.dataTransfer.files;
             for (const file of Array.from(files)) {
-              if (["image/png","image/jpeg","image/webp"].includes(file.type)) {
-                const url = URL.createObjectURL(file)
-                addDroppedImage(url)
+              if (
+                ["image/png", "image/jpeg", "image/webp"].includes(file.type)
+              ) {
+                const url = URL.createObjectURL(file);
+                addDroppedImage(url);
               }
             }
-            const uri = e.dataTransfer.getData("text/uri-list") || e.dataTransfer.getData("text/plain")
-            if (uri && uri.match(/\.(png|jpe?g|webp)$/i)) addDroppedImage(uri.trim())
+            const uri =
+              e.dataTransfer.getData("text/uri-list") ||
+              e.dataTransfer.getData("text/plain");
+            if (uri && uri.match(/\.(png|jpe?g|webp)$/i))
+              addDroppedImage(uri.trim());
           }}
         >
           <CanvasView
@@ -505,90 +698,302 @@ export default function ScenesEditor() {
             onMouseDown={handleMouseDown}
             onMouseMove={handleMouseMove}
             onMouseUp={handleMouseUp}
-            style={{ position:"absolute", top:0, left:0, width:"100%", height:"100%" }}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              height: "100%",
+            }}
           />
         </div>
       </section>
-      <aside style={{ borderLeft:"1px solid #eee", padding:12, overflowY:"auto" }}>
+      <aside
+        style={{ borderLeft: "1px solid #eee", padding: 12, overflowY: "auto" }}
+      >
         {activeScene && (
           <>
             <strong>Слои</strong>
             <LayerPanel
               layers={activeScene.layers}
               selectedId={selectedLayerId || undefined}
-              onSelect={id => setSelectedLayerId(id)}
+              onSelect={(id) => setSelectedLayerId(id)}
               onAddImage={addImageLayer}
               onAddColor={addColorLayer}
               onReorder={reorderLayers}
               onDelete={deleteLayer}
               onCopy={copyLayer}
             />
-            <LayerInspector layer={activeLayer} onChange={l => updateLayer(l.id, l)} />
-            <strong style={{ marginTop:8, display:"block" }}>Параметры сцены</strong>
-            <div style={{ display:"flex", flexDirection:"column", gap:4, marginBottom:8 }}>
-              <label>Название
-                <input value={activeScene.name||""} onChange={e=>handleSceneNameChange(e.target.value)} />
+            <LayerInspector
+              layer={activeLayer}
+              onChange={(l) => updateLayer(l.id, l)}
+            />
+            <strong style={{ marginTop: 8, display: "block" }}>
+              Параметры сцены
+            </strong>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 4,
+                marginBottom: 8,
+              }}
+            >
+              <label>
+                Название
+                <input
+                  value={activeScene.name || ""}
+                  onChange={(e) => handleSceneNameChange(e.target.value)}
+                />
               </label>
             </div>
             <strong>Элементы</strong>
-            <ul style={{ listStyle:"none", padding:0 }}>
-              {activeScene.hotspots?.map((hs,i)=> (
-                <li key={hs.id} style={{ display:"flex", alignItems:"center", gap:4 }}>
-                  <button onClick={()=>toggleHotspotVisibility(i)}>{hs.hidden?"🙈":"👁️"}</button>
-                  <button onClick={()=>setSelectedHs(i)} style={{ fontWeight:selectedHs===i?600:400 }}>
+            <ul style={{ listStyle: "none", padding: 0 }}>
+              {activeScene.hotspots?.map((hs, i) => (
+                <li
+                  key={hs.id}
+                  style={{ display: "flex", alignItems: "center", gap: 4 }}
+                >
+                  <button onClick={() => toggleHotspotVisibility(i)}>
+                    {hs.hidden ? "🙈" : "👁️"}
+                  </button>
+                  <button
+                    onClick={() => setSelectedHs(i)}
+                    style={{ fontWeight: selectedHs === i ? 600 : 400 }}
+                  >
                     {hs.tooltip || hs.id}
                   </button>
                 </li>
               ))}
             </ul>
             {activeHotspot && (
-              <div style={{ marginTop:8 }}>
+              <div style={{ marginTop: 8 }}>
                 <strong>Свойства</strong>
                 {activeHotspot.shape === "rect" && activeHotspot.rect && (
-                  <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:4 }}>
-                    <label>X<input type="number" step="0.001" value={activeHotspot.rect.x} onChange={e=>updateHotspot(selectedHs!, { ...activeHotspot, rect:{ ...activeHotspot.rect!, x: round3(parseFloat(e.target.value)) } })} /></label>
-                    <label>Y<input type="number" step="0.001" value={activeHotspot.rect.y} onChange={e=>updateHotspot(selectedHs!, { ...activeHotspot, rect:{ ...activeHotspot.rect!, y: round3(parseFloat(e.target.value)) } })} /></label>
-                    <label>W<input type="number" step="0.001" value={activeHotspot.rect.w} onChange={e=>updateHotspot(selectedHs!, { ...activeHotspot, rect:{ ...activeHotspot.rect!, w: round3(parseFloat(e.target.value)) } })} /></label>
-                    <label>H<input type="number" step="0.001" value={activeHotspot.rect.h} onChange={e=>updateHotspot(selectedHs!, { ...activeHotspot, rect:{ ...activeHotspot.rect!, h: round3(parseFloat(e.target.value)) } })} /></label>
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr 1fr",
+                      gap: 4,
+                    }}
+                  >
+                    <label>
+                      X
+                      <input
+                        type="number"
+                        step="0.001"
+                        value={activeHotspot.rect.x}
+                        onChange={(e) =>
+                          updateHotspot(selectedHs!, {
+                            ...activeHotspot,
+                            rect: {
+                              ...activeHotspot.rect!,
+                              x: round3(parseFloat(e.target.value)),
+                            },
+                          })
+                        }
+                      />
+                    </label>
+                    <label>
+                      Y
+                      <input
+                        type="number"
+                        step="0.001"
+                        value={activeHotspot.rect.y}
+                        onChange={(e) =>
+                          updateHotspot(selectedHs!, {
+                            ...activeHotspot,
+                            rect: {
+                              ...activeHotspot.rect!,
+                              y: round3(parseFloat(e.target.value)),
+                            },
+                          })
+                        }
+                      />
+                    </label>
+                    <label>
+                      W
+                      <input
+                        type="number"
+                        step="0.001"
+                        value={activeHotspot.rect.w}
+                        onChange={(e) =>
+                          updateHotspot(selectedHs!, {
+                            ...activeHotspot,
+                            rect: {
+                              ...activeHotspot.rect!,
+                              w: round3(parseFloat(e.target.value)),
+                            },
+                          })
+                        }
+                      />
+                    </label>
+                    <label>
+                      H
+                      <input
+                        type="number"
+                        step="0.001"
+                        value={activeHotspot.rect.h}
+                        onChange={(e) =>
+                          updateHotspot(selectedHs!, {
+                            ...activeHotspot,
+                            rect: {
+                              ...activeHotspot.rect!,
+                              h: round3(parseFloat(e.target.value)),
+                            },
+                          })
+                        }
+                      />
+                    </label>
                   </div>
                 )}
                 {activeHotspot.shape === "circle" && activeHotspot.circle && (
-                  <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:4 }}>
-                    <label>CX<input type="number" step="0.001" value={activeHotspot.circle.cx} onChange={e=>updateHotspot(selectedHs!, { ...activeHotspot, circle:{ ...activeHotspot.circle!, cx: round3(parseFloat(e.target.value)) } })} /></label>
-                    <label>CY<input type="number" step="0.001" value={activeHotspot.circle.cy} onChange={e=>updateHotspot(selectedHs!, { ...activeHotspot, circle:{ ...activeHotspot.circle!, cy: round3(parseFloat(e.target.value)) } })} /></label>
-                    <label>R<input type="number" step="0.001" value={activeHotspot.circle.r} onChange={e=>updateHotspot(selectedHs!, { ...activeHotspot, circle:{ ...activeHotspot.circle!, r: round3(parseFloat(e.target.value)) } })} /></label>
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr 1fr",
+                      gap: 4,
+                    }}
+                  >
+                    <label>
+                      CX
+                      <input
+                        type="number"
+                        step="0.001"
+                        value={activeHotspot.circle.cx}
+                        onChange={(e) =>
+                          updateHotspot(selectedHs!, {
+                            ...activeHotspot,
+                            circle: {
+                              ...activeHotspot.circle!,
+                              cx: round3(parseFloat(e.target.value)),
+                            },
+                          })
+                        }
+                      />
+                    </label>
+                    <label>
+                      CY
+                      <input
+                        type="number"
+                        step="0.001"
+                        value={activeHotspot.circle.cy}
+                        onChange={(e) =>
+                          updateHotspot(selectedHs!, {
+                            ...activeHotspot,
+                            circle: {
+                              ...activeHotspot.circle!,
+                              cy: round3(parseFloat(e.target.value)),
+                            },
+                          })
+                        }
+                      />
+                    </label>
+                    <label>
+                      R
+                      <input
+                        type="number"
+                        step="0.001"
+                        value={activeHotspot.circle.r}
+                        onChange={(e) =>
+                          updateHotspot(selectedHs!, {
+                            ...activeHotspot,
+                            circle: {
+                              ...activeHotspot.circle!,
+                              r: round3(parseFloat(e.target.value)),
+                            },
+                          })
+                        }
+                      />
+                    </label>
                   </div>
                 )}
                 {activeHotspot.shape === "polygon" && activeHotspot.points && (
-                  <div style={{ display:"flex", flexDirection:"column", gap:4 }}>
-                    <label>Количество точек
-                      <input type="number" min={3} value={activeHotspot.points.length} onChange={e=>{
-                        const n = parseInt(e.target.value)
-                        let pts: [number, number][] = [...(activeHotspot.points as [number,number][])]
-                        if (n > pts.length) {
-                          const last = pts[pts.length-1]
-                          while (pts.length < n) pts.push([...last] as [number,number])
-                        } else if (n < pts.length) {
-                          pts = pts.slice(0,n)
-                        }
-                        updateHotspot(selectedHs!, { ...activeHotspot, points: pts as [number,number][] })
-                      }} />
+                  <div
+                    style={{ display: "flex", flexDirection: "column", gap: 4 }}
+                  >
+                    <label>
+                      Количество точек
+                      <input
+                        type="number"
+                        min={3}
+                        value={activeHotspot.points.length}
+                        onChange={(e) => {
+                          const n = parseInt(e.target.value);
+                          let pts: [number, number][] = [
+                            ...(activeHotspot.points as [number, number][]),
+                          ];
+                          if (n > pts.length) {
+                            const last = pts[pts.length - 1];
+                            while (pts.length < n)
+                              pts.push([...last] as [number, number]);
+                          } else if (n < pts.length) {
+                            pts = pts.slice(0, n);
+                          }
+                          updateHotspot(selectedHs!, {
+                            ...activeHotspot,
+                            points: pts as [number, number][],
+                          });
+                        }}
+                      />
                     </label>
-                    {activeHotspot.points.map((pt,i)=> (
-                      <div key={i} style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:4 }}>
-                        <input type="number" step="0.001" value={pt[0]} onChange={e=>{
-                          const pts = activeHotspot.points!.map((p,j)=> j===i?[round3(parseFloat(e.target.value)),p[1]] as [number,number]:p as [number,number])
-                          updateHotspot(selectedHs!, { ...activeHotspot, points: pts as [number,number][] })
-                        }} />
-                        <input type="number" step="0.001" value={pt[1]} onChange={e=>{
-                          const pts = activeHotspot.points!.map((p,j)=> j===i?[p[0],round3(parseFloat(e.target.value))] as [number,number]:p as [number,number])
-                          updateHotspot(selectedHs!, { ...activeHotspot, points: pts as [number,number][] })
-                        }} />
+                    {activeHotspot.points.map((pt, i) => (
+                      <div
+                        key={i}
+                        style={{
+                          display: "grid",
+                          gridTemplateColumns: "1fr 1fr",
+                          gap: 4,
+                        }}
+                      >
+                        <input
+                          type="number"
+                          step="0.001"
+                          value={pt[0]}
+                          onChange={(e) => {
+                            const pts = activeHotspot.points!.map((p, j) =>
+                              j === i
+                                ? ([
+                                    round3(parseFloat(e.target.value)),
+                                    p[1],
+                                  ] as [number, number])
+                                : (p as [number, number]),
+                            );
+                            updateHotspot(selectedHs!, {
+                              ...activeHotspot,
+                              points: pts as [number, number][],
+                            });
+                          }}
+                        />
+                        <input
+                          type="number"
+                          step="0.001"
+                          value={pt[1]}
+                          onChange={(e) => {
+                            const pts = activeHotspot.points!.map((p, j) =>
+                              j === i
+                                ? ([
+                                    p[0],
+                                    round3(parseFloat(e.target.value)),
+                                  ] as [number, number])
+                                : (p as [number, number]),
+                            );
+                            updateHotspot(selectedHs!, {
+                              ...activeHotspot,
+                              points: pts as [number, number][],
+                            });
+                          }}
+                        />
                       </div>
                     ))}
                   </div>
                 )}
-                <HotspotContext.Provider value={{ hotspot: activeHotspot, setHotspot: hs => updateHotspot(selectedHs!, hs) }}>
+                <HotspotContext.Provider
+                  value={{
+                    hotspot: activeHotspot,
+                    setHotspot: (hs) => updateHotspot(selectedHs!, hs),
+                  }}
+                >
                   <HotspotInspector />
                 </HotspotContext.Provider>
               </div>
@@ -597,8 +1002,13 @@ export default function ScenesEditor() {
         )}
       </aside>
       {preview && activeSceneId && (
-        <CanvasView project={proj} sceneId={activeSceneId} useWebGL={useWebGL} onExit={closePreview} />
+        <CanvasView
+          project={proj}
+          sceneId={activeSceneId}
+          useWebGL={useWebGL}
+          onExit={closePreview}
+        />
       )}
     </div>
-  )
+  );
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,24 @@
+import type { SceneProject } from "@core/sceneSchema";
+import { parseSceneProject } from "@core/scenePersistence";
+
+const API_BASE = "";
+
+export async function fetchScenes(): Promise<SceneProject> {
+  const res = await fetch(`${API_BASE}/scenes`);
+  if (!res.ok) {
+    throw new Error("Failed to fetch scenes");
+  }
+  const data = await res.json();
+  return parseSceneProject(data);
+}
+
+export async function saveScene(proj: SceneProject): Promise<void> {
+  const res = await fetch(`${API_BASE}/scenes`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(proj),
+  });
+  if (!res.ok) {
+    throw new Error("Failed to save scene");
+  }
+}


### PR DESCRIPTION
## Summary
- add frontend API service with `fetchScenes` and `saveScene`
- load and save scenes through API instead of localStorage
- drop JSON import/export buttons from scene and dialog editors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a179b12b08333b476747504370b18