### PR TITLE
feat: add CLI for generating .rpy scenes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 *.log
 *.tmp
 *.bak
+_gen/
 # Editor
 .vscode/
 .idea/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint:fix": "eslint . --ext .ts,.tsx,.js --fix",
     "test": "vitest run",
     "format": "prettier --write .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "scene-gen": "node scripts/scene-gen.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/packages/core/sceneSchema.js
+++ b/packages/core/sceneSchema.js
@@ -1,0 +1,98 @@
+import { z } from 'zod'
+
+export const Rect = z.object({ x: z.number(), y: z.number(), w: z.number(), h: z.number() })
+export const Circle = z.object({ cx: z.number(), cy: z.number(), r: z.number() })
+export const PointSchema = z.tuple([z.number(), z.number()])
+
+function exprValid(expr) {
+  if (!expr) return true
+  try {
+    // eslint-disable-next-line no-new-func
+    new Function(`return (${expr})`)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const Transition = z.object({
+  type: z.string(),
+  duration: z.number().optional(),
+  easing: z.string().optional(),
+})
+
+const Action = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('go_scene'), scene_id: z.string(), transition: Transition.optional() }),
+  z.object({ type: z.literal('jump_label'), label: z.string() }),
+  z.object({ type: z.literal('call_label'), label: z.string() }),
+  z.object({ type: z.literal('call_screen'), screen: z.string(), params: z.record(z.any()).optional() }),
+  z.object({ type: z.literal('function'), name: z.string(), params: z.record(z.any()).optional() }),
+])
+
+export const HotspotSchema = z.object({
+  id: z.string(),
+  shape: z.enum(['rect','polygon','circle']),
+  rect: Rect.optional(),
+  points: z.array(PointSchema).optional(),
+  circle: Circle.optional(),
+  tooltip: z.string().optional(),
+  hover_effect: z.record(z.any()).optional(),
+  visible_if: z.string().optional().refine(exprValid, { message: 'Invalid expression' }),
+  enabled_if: z.string().optional().refine(exprValid, { message: 'Invalid expression' }),
+  action: Action.optional(),
+  hidden: z.boolean().default(false)
+})
+
+const LayerImage = z.object({
+  id: z.string(),
+  type: z.literal('image'),
+  image: z.string(),
+  alpha: z.number().default(1),
+  zorder: z.number().default(0),
+  enter_transition: Transition.optional(),
+  exit_transition: Transition.optional(),
+})
+
+const LayerColor = z.object({
+  id: z.string(),
+  type: z.literal('color'),
+  color: z.string(),
+  alpha: z.number().default(1),
+  zorder: z.number().default(0),
+  enter_transition: Transition.optional(),
+  exit_transition: Transition.optional(),
+})
+
+const LayerSchema = z.discriminatedUnion('type', [LayerImage, LayerColor])
+
+const Scene = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  enter_transition: Transition.optional(),
+  layers: z.array(LayerSchema).default([]),
+  hotspots: z.array(HotspotSchema).default([])
+})
+
+const Project = z.object({
+  reference_resolution: z.object({ width: z.number(), height: z.number() }),
+  coords_mode: z.enum(['relative','absolute']).default('relative')
+})
+
+export const SceneProjectSchema = z.object({
+  version: z.string().default('1.0'),
+  project: Project,
+  scenes: z.array(Scene).default([])
+})
+
+export function validateSceneProject(data) {
+  const parsed = SceneProjectSchema.parse(data)
+  return parsed
+}
+
+export function emptyProject() {
+  return {
+    version: '1.0',
+    project: { reference_resolution: { width: 1920, height: 1080 }, coords_mode: 'relative' },
+    scenes: []
+  }
+}

--- a/scripts/scene-gen.js
+++ b/scripts/scene-gen.js
@@ -1,0 +1,45 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { validateSceneProject } from '../packages/core/sceneSchema.js'
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (args.length < 1) {
+    console.error('Usage: scene-gen <input.json> [outputDir]')
+    process.exit(1)
+  }
+  const [inputPath, outDir = '_gen'] = args
+  const json = await fs.readFile(inputPath, 'utf8')
+  const data = JSON.parse(json)
+  const project = validateSceneProject(data)
+
+  const outPath = path.resolve(outDir)
+  await fs.rm(outPath, { recursive: true, force: true })
+  await fs.mkdir(outPath, { recursive: true })
+
+  for (const scene of project.scenes) {
+    const lines = []
+    lines.push(`# Auto-generated file. Do not edit.`)
+    lines.push(`screen scene_${scene.id}():`)
+    lines.push('    zorder 10')
+    for (const layer of scene.layers) {
+      if (layer.type === 'image') {
+        lines.push(`    add "${layer.image}"`)
+      } else if (layer.type === 'color') {
+        lines.push(`    add Solid("${layer.color}") alpha ${layer.alpha}`)
+      }
+    }
+    lines.push('')
+    lines.push(`label show_${scene.id}:`)
+    lines.push(`    show screen scene_${scene.id}`)
+    lines.push('    return')
+
+    const fileName = path.join(outPath, `scene_${scene.id}.rpy`)
+    await fs.writeFile(fileName, lines.join('\n'), 'utf8')
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add Node-based `scene-gen` script to validate scene JSON and emit `.rpy` files
- expose core scene schema for runtime validation
- ignore generated `_gen/` directory

## Testing
- `npm test`
- `node scripts/scene-gen.js samples/scenes.json`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689a1907898083339884b6d18b155c3e