### PR TITLE
Refactor backend routes to async with fs/promises

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import swaggerUi from 'swagger-ui-express';
@@ -15,46 +15,68 @@ const dataDir = path.join(__dirname, 'data');
 const scenesPath = path.join(dataDir, 'scenes.json');
 const dialogsPath = path.join(dataDir, 'dialogs.json');
 
-function readData(filePath, key) {
-  if (!fs.existsSync(filePath)) {
-    const initial = { schema_version: 1 };
-    initial[key] = [];
-    fs.writeFileSync(filePath, JSON.stringify(initial, null, 2));
-    return initial;
+async function readData(filePath, key) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(content);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      const initial = { schema_version: 1 };
+      initial[key] = [];
+      await fs.writeFile(filePath, JSON.stringify(initial, null, 2));
+      return initial;
+    }
+    throw err;
   }
-  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
 }
 
-function writeData(filePath, data) {
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+async function writeData(filePath, data) {
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2));
 }
 
-app.get('/scenes', (req, res) => {
-  const data = readData(scenesPath, 'scenes');
-  res.json(data);
+app.get('/scenes', async (req, res) => {
+  try {
+    const data = await readData(scenesPath, 'scenes');
+    res.json(data);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
 });
 
-app.post('/scenes', (req, res) => {
-  const data = readData(scenesPath, 'scenes');
-  const newScene = req.body;
-  data.scenes.push(newScene);
-  data.schema_version++;
-  writeData(scenesPath, data);
-  res.status(201).json(newScene);
+app.post('/scenes', async (req, res) => {
+  try {
+    const data = await readData(scenesPath, 'scenes');
+    const newScene = req.body;
+    data.scenes.push(newScene);
+    data.schema_version++;
+    await writeData(scenesPath, data);
+    res.status(201).json(newScene);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
 });
 
-app.get('/dialogs', (req, res) => {
-  const data = readData(dialogsPath, 'dialogs');
-  res.json(data);
+app.get('/dialogs', async (req, res) => {
+  try {
+    const data = await readData(dialogsPath, 'dialogs');
+    res.json(data);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
 });
 
-app.post('/dialogs', (req, res) => {
-  const data = readData(dialogsPath, 'dialogs');
-  const newDialog = req.body;
-  data.dialogs.push(newDialog);
-  data.schema_version++;
-  writeData(dialogsPath, data);
-  res.status(201).json(newDialog);
+app.post('/dialogs', async (req, res) => {
+  try {
+    const data = await readData(dialogsPath, 'dialogs');
+    const newDialog = req.body;
+    data.dialogs.push(newDialog);
+    data.schema_version++;
+    await writeData(dialogsPath, data);
+    res.status(201).json(newDialog);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
 });
 
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(openapi));


### PR DESCRIPTION
## Summary
- refactor backend to use `fs/promises`
- make scene and dialog routes asynchronous with error handling
- ensure data directory exists before reading or writing

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any, etc.)*
- `npx eslint apps/backend/server.js`


------
https://chatgpt.com/codex/tasks/task_e_689a2198403c8333bfb23e981e8a9749