### PR TITLE
feat: configure backend data path via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ npm run dev
 npm run build && npm run preview
 ```
 
+## Переменные окружения
+
+- `DATA_DIR` — путь к директории с `scenes.json` и `dialogs.json` для бэкенда (`apps/backend/server.js`).
+  По умолчанию используется `data/` рядом с сервером.
+
 ## Архитектура
 - **/packages/core/src/** — типы и схемы (Zod), утилиты импорта/экспорта.
 - **/src/components/** — ScenesEditor (канвас с хотспотами), DialogEditor (граф на React Flow).

--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -11,7 +11,7 @@ const __dirname = path.dirname(__filename);
 const app = express();
 app.use(express.json());
 
-const dataDir = path.join(__dirname, 'data');
+const dataDir = path.resolve(__dirname, process.env.DATA_DIR || 'data');
 const scenesPath = path.join(dataDir, 'scenes.json');
 const dialogsPath = path.join(dataDir, 'dialogs.json');
 


### PR DESCRIPTION
## Summary
- allow overriding backend data directory using `DATA_DIR`
- document `DATA_DIR` environment variable

## Testing
- `npm test`
- `npm run lint` *(fails: 42 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689a21994f908333bbf250660c9b4023