### PR TITLE
feat: limit undo history length

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createUndoStore } from "./store";
+
+describe("createUndoStore", () => {
+  it("limits history stacks", () => {
+    const maxHistory = 3;
+    const store = createUndoStore<number>(0, (v) => v, maxHistory);
+    const { setProj, undo } = store.getState();
+
+    for (let i = 1; i <= maxHistory + 2; i++) {
+      setProj(i);
+    }
+    expect(store.getState().undoStack).toHaveLength(maxHistory);
+
+    for (let i = 0; i < maxHistory + 2; i++) {
+      undo();
+    }
+    expect(store.getState().redoStack).toHaveLength(maxHistory);
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable `maxHistory` to `createUndoStore` with default 50 and trim undo/redo stacks
- test that undo/redo stacks are limited to specified history size

## Testing
- `npm test`
- `npx eslint src/store.ts src/store.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a219d32288333a2782c4e593a320d