### PR TITLE
Improve canvas scaling and expand sample scenes

### DIFF
--- a/apps/backend/schemas.js
+++ b/apps/backend/schemas.js
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { SceneProjectSchema } from '../../packages/core/sceneSchema.js';
 
-export const SceneSchema = SceneProjectSchema.shape.scenes.element;
+export const SceneSchema = SceneProjectSchema.shape.scenes._def.innerType.element;
 
 const Choice = z.object({
   text: z.string().default(''),

--- a/apps/backend/test/server.test.js
+++ b/apps/backend/test/server.test.js
@@ -25,13 +25,14 @@ describe('Scenes API', () => {
   });
 
   it('POST /scenes adds new scene', async () => {
-    const scene = { id: 1, name: 'Test Scene' };
+    const scene = { id: '1', name: 'Test Scene' };
     const postRes = await request(app).post('/scenes').send(scene);
     expect(postRes.status).toBe(201);
-    expect(postRes.body).toEqual(scene);
+    expect(postRes.body).toMatchObject(scene);
 
     const getRes = await request(app).get('/scenes');
-    expect(getRes.body.scenes).toEqual([scene]);
+    expect(getRes.body.scenes.length).toBe(1);
+    expect(getRes.body.scenes[0]).toMatchObject(scene);
     expect(getRes.body.schema_version).toBe(2);
   });
 });
@@ -56,13 +57,14 @@ describe('Dialogs API', () => {
   });
 
   it('POST /dialogs adds new dialog', async () => {
-    const dialog = { id: 1, text: 'Hello' };
+    const dialog = { id: '1', nodes: [{ id: 'n1', text: 'Hello' }] };
     const postRes = await request(app).post('/dialogs').send(dialog);
     expect(postRes.status).toBe(201);
-    expect(postRes.body).toEqual(dialog);
+    expect(postRes.body).toMatchObject(dialog);
 
     const getRes = await request(app).get('/dialogs');
-    expect(getRes.body.dialogs).toEqual([dialog]);
+    expect(getRes.body.dialogs.length).toBe(1);
+    expect(getRes.body.dialogs[0]).toMatchObject(dialog);
     expect(getRes.body.schema_version).toBe(2);
   });
 });

--- a/public/samples/scenes.json
+++ b/public/samples/scenes.json
@@ -137,6 +137,56 @@
           }
         }
       ]
+    },
+    {
+      "id": "library",
+      "name": "Библиотека",
+      "enter_transition": {
+        "type": "fade",
+        "duration": 0.2
+      },
+      "layers": [
+        {
+          "id": "bg",
+          "type": "image",
+          "image": "bg/library_day.jpg",
+          "zorder": 0
+        }
+      ],
+      "hotspots": [
+        {
+          "id": "back_to_hall_from_library",
+          "shape": "rect",
+          "rect": { "x": 0.05, "y": 0.8, "w": 0.1, "h": 0.15 },
+          "tooltip": "В коридор",
+          "action": { "type": "go_scene", "scene_id": "hall" }
+        }
+      ]
+    },
+    {
+      "id": "courtyard",
+      "name": "Двор",
+      "enter_transition": {
+        "type": "dissolve",
+        "duration": 0.2
+      },
+      "layers": [
+        {
+          "id": "bg",
+          "type": "image",
+          "image": "bg/courtyard_day.jpg",
+          "zorder": 0
+        }
+      ],
+      "hotspots": [
+        {
+          "id": "back_to_hall_from_courtyard",
+          "shape": "rect",
+          "rect": { "x": 0.9, "y": 0.8, "w": 0.1, "h": 0.15 },
+          "tooltip": "В коридор",
+          "action": { "type": "go_scene", "scene_id": "hall" }
+        }
+      ]
     }
   ]
 }

--- a/samples/scenes.json
+++ b/samples/scenes.json
@@ -137,6 +137,56 @@
           }
         }
       ]
+    },
+    {
+      "id": "library",
+      "name": "Библиотека",
+      "enter_transition": {
+        "type": "fade",
+        "duration": 0.2
+      },
+      "layers": [
+        {
+          "id": "bg",
+          "type": "image",
+          "image": "bg/library_day.jpg",
+          "zorder": 0
+        }
+      ],
+      "hotspots": [
+        {
+          "id": "back_to_hall_from_library",
+          "shape": "rect",
+          "rect": { "x": 0.05, "y": 0.8, "w": 0.1, "h": 0.15 },
+          "tooltip": "В коридор",
+          "action": { "type": "go_scene", "scene_id": "hall" }
+        }
+      ]
+    },
+    {
+      "id": "courtyard",
+      "name": "Двор",
+      "enter_transition": {
+        "type": "dissolve",
+        "duration": 0.2
+      },
+      "layers": [
+        {
+          "id": "bg",
+          "type": "image",
+          "image": "bg/courtyard_day.jpg",
+          "zorder": 0
+        }
+      ],
+      "hotspots": [
+        {
+          "id": "back_to_hall_from_courtyard",
+          "shape": "rect",
+          "rect": { "x": 0.9, "y": 0.8, "w": 0.1, "h": 0.15 },
+          "tooltip": "В коридор",
+          "action": { "type": "go_scene", "scene_id": "hall" }
+        }
+      ]
     }
   ]
 }

--- a/src/components/CanvasView.tsx
+++ b/src/components/CanvasView.tsx
@@ -77,17 +77,6 @@ export default function CanvasView(props: CanvasViewProps) {
 
   if (onExit) {
     return (
-      <div
-        style={{
-          position: 'fixed',
-          inset: 0,
-          background: '#000',
-          zIndex: 1000,
-        }}
-        onClick={onExit}
-      >
-        {canvasElement}
-      </div>
       <FullscreenCanvasOverlay onExit={onExit}>
         {canvasElement}
       </FullscreenCanvasOverlay>


### PR DESCRIPTION
## Summary
- make ScenesEditor canvas responsive and honor project aspect ratio
- fix CanvasView overlay rendering
- add library and courtyard sample scenes
- fix backend scene schema reference and update API tests

## Testing
- `node -e "const fs=require('fs'); ['samples/scenes.json','public/samples/scenes.json','samples/dialogs.example.json','schema/scene.schema.json','schema/dialog.schema.json'].forEach(f=>{JSON.parse(fs.readFileSync(f,'utf8')); console.log(f+' OK');});"`
- `npm test`
- `npm run lint` *(fails: Unexpected any, 52 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a34983d448333947375410fc74e97